### PR TITLE
fix: DRY clone-repos, gitignore sandbox artifacts, widen status output

### DIFF
--- a/.devcontainer/clone-repos.sh
+++ b/.devcontainer/clone-repos.sh
@@ -1,25 +1,18 @@
 #!/bin/bash
 # Clone all managed repos into the workspace
-# Sourced repo list from repos.conf, GitHub org derived from polyforge remote
+# Derives GitHub owner/repo from repos.conf paths — single source of truth
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../scripts/repos.conf"
 
-# GitHub repo names matching repos.conf order
-GITHUB_REPOS=(
-  qte77/Agents-eval
-  qte77/claude-code-research
-  qte77/CABIO-test
-  qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
-  qte77/claude-code-utils-plugin
-  qte77/deepvariant-linux-arm64
-)
+# Default GitHub org (override via GITHUB_ORG env var)
+ORG="${GITHUB_ORG:-qte77}"
 
-for i in "${!GITHUB_REPOS[@]}"; do
+for i in "${!REPOS[@]}"; do
   path="${REPOS[$i]}"
-  gh_repo="${GITHUB_REPOS[$i]}"
+  name=$(basename "$path")
 
   if [[ -d "$path" ]]; then
     echo "  ${REPO_NAMES[$i]}: exists (skipping)"
@@ -28,8 +21,8 @@ for i in "${!GITHUB_REPOS[@]}"; do
 
   echo "  ${REPO_NAMES[$i]}: cloning..."
   mkdir -p "$(dirname "$path")"
-  git clone "https://github.com/${gh_repo}.git" "$path" 2>/dev/null || \
-    echo "  WARNING: Failed to clone ${gh_repo}"
+  git clone "https://github.com/${ORG}/${name}.git" "$path" 2>/dev/null || \
+    echo "  WARNING: Failed to clone ${ORG}/${name}"
 done
 
 echo "Done. $(ls -d "${REPOS[@]}" 2>/dev/null | wc -l)/${#REPOS[@]} repos available."

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .env
 *.log
+# Sandbox device nodes (denyWithinAllow artifacts)
+HEAD
+hooks
+objects
+refs

--- a/docs/settings-consolidation.md
+++ b/docs/settings-consolidation.md
@@ -30,4 +30,3 @@ Remove `sandbox.filesystem` from project-level settings entirely. User-level `~/
 - `/workspaces/Agents-eval/.claude/settings.json` — removed redundant `sandbox.filesystem` block
 - `/workspaces/qte77/claude-code-research/.claude/settings.json` — removed redundant `sandbox.filesystem` block
 - User-level `~/.claude/settings.json` — single source of truth for `additionalDirectories` + `allowWrite`
-- Reference docs: `polyforge/docs/cross-repo-setup.md`, `polyforge/docs/sandbox-friction.md`

--- a/scripts/cc-status.sh
+++ b/scripts/cc-status.sh
@@ -43,7 +43,7 @@ for repo in "${REPOS[@]}"; do
   fi
 
   # Last commit
-  last_commit=$(git -C "$repo" log -1 --format='%ar: %s' 2>/dev/null | head -c 50)
+  last_commit=$(git -C "$repo" log -1 --format='%ar: %s' 2>/dev/null | head -c 70)
 
   printf "%-28s %-20s %-7s %-8s %s\n" "$name" "$branch" "$status" "$ralph_state" "$last_commit"
 


### PR DESCRIPTION
## Summary

- `clone-repos.sh`: derive owner/repo from `repos.conf` paths — eliminates duplicate `GITHUB_REPOS` array
- `.gitignore`: exclude sandbox device nodes (`HEAD`, `hooks`, `objects`, `refs`)
- `settings-consolidation.md`: remove circular self-reference
- `cc-status.sh`: widen last commit column (50 -> 70 chars)

## Test plan

- [ ] `./scripts/cc-status.sh` shows full commit messages
- [ ] `git status` no longer shows sandbox artifacts

Generated with Claude <noreply@anthropic.com>