### PR TITLE
fix(devcontainer): WakaTime non-interactive setup, dynamic paths, tmux

### DIFF
--- a/.devcontainer/clone-repos.sh
+++ b/.devcontainer/clone-repos.sh
@@ -26,3 +26,9 @@ for i in "${!REPOS[@]}"; do
 done
 
 echo "Done. $(ls -d "${REPOS[@]}" 2>/dev/null | wc -l)/${#REPOS[@]} repos available."
+
+# Seed WakaTime config from Codespace secret (prevents interactive prompt)
+if [[ -n "${WAKATIME_API_KEY:-}" && ! -f "$HOME/.wakatime.cfg" ]]; then
+  printf '[settings]\napi_key = %s\n' "$WAKATIME_API_KEY" > "$HOME/.wakatime.cfg"
+  echo "WakaTime: config seeded from WAKATIME_API_KEY"
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {}
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-contrib/features/tmux:1": {}
   },
   "customizations": {
     "vscode": {
@@ -33,8 +34,9 @@
     }
   },
   "containerEnv": {
-    "GH_PAT": "${localEnv:GH_PAT}"
+    "GH_PAT": "${localEnv:GH_PAT}",
+    "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
-  "onCreateCommand": "bash .devcontainer/clone-repos.sh",
-  "postAttachCommand": "code workspace.code-workspace && bash scripts/cc-repos.sh"
+  "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
+  "postAttachCommand": "echo '→ Open workspace: Ctrl+Shift+P → Open Workspace from File → workspace.code-workspace' && bash scripts/cc-repos.sh"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 *.log
+workspace.code-workspace
 # Sandbox device nodes (denyWithinAllow artifacts)
 HEAD
 hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` dynamically from `repos.conf`
+- WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
+- tmux devcontainer feature for `cc-repos.sh` tmux sessions
+
+### Changed
+
+- `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
+- `workspace.code-workspace` is now generated (added to `.gitignore`)
+- `postAttachCommand`: replaced `code workspace.code-workspace` with user instruction echo
+
+### Fixed
+
+- Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
+- tmux not available in devcontainer (missing feature)
+
 ## [0.0.1] - 2026-03-17
 
 ### Added

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Generate workspace.code-workspace from repos.conf
+# Ensures paths match the actual runtime environment
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/repos.conf"
+
+WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
+folders=""
+for i in "${!REPOS[@]}"; do
+  [[ -n "$folders" ]] && folders+=","
+  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
+done
+
+cat > "$WORKSPACE_FILE" <<EOF
+{
+  "folders": [${folders}
+  ]
+}
+EOF
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders"

--- a/scripts/repos.conf
+++ b/scripts/repos.conf
@@ -1,6 +1,10 @@
 # Shared repo list — sourced by all polyforge scripts
 # Add/remove repos here. All scripts use this single source of truth.
 
+# Resolve polyforge root dynamically (works whether repo is at
+# /workspaces/polyforge or /workspaces/qte77/polyforge)
+POLYFORGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 REPOS=(
   /workspaces/Agents-eval
   /workspaces/qte77/claude-code-research
@@ -8,7 +12,7 @@ REPOS=(
   /workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
   /workspaces/qte77/claude-code-utils-plugin
   /workspaces/qte77/deepvariant-linux-arm64
-  /workspaces/qte77/polyforge
+  "${POLYFORGE_ROOT}"
 )
 
 # Ordered names for display (parallel arrays)


### PR DESCRIPTION
## Summary

- Seed `~/.wakatime.cfg` from `WAKATIME_API_KEY` Codespace secret (prevents interactive prompt on rebuild)
- Dynamic `POLYFORGE_ROOT` in `repos.conf` — fixes sidebar path mismatch when polyforge is the main Codespace repo
- Generate `workspace.code-workspace` from `repos.conf` at build time (gitignored)
- Add tmux devcontainer feature for `cc-repos.sh` sessions
- Replace `code workspace.code-workspace` (opened new window) with user instruction echo

## Test plan

- [ ] `source scripts/repos.conf && echo "${REPOS[@]}"` — polyforge path matches actual location
- [ ] `bash scripts/generate-workspace.sh` — creates workspace.code-workspace with correct paths
- [ ] `bash scripts/cc-status.sh` — all repos resolve (polyforge at correct path)
- [ ] Rebuild Codespace: WakaTime doesn't prompt, tmux starts, sidebar loads after opening workspace file
- [ ] Verify `WAKATIME_API_KEY` is set as Codespaces encrypted secret before rebuild

Generated with Claude <noreply@anthropic.com>