### PR TITLE
feat: add CC Web cloud workflow adaptation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,23 @@ Best long-term approach: Codespaces encrypted secrets via `containerEnv` in `dev
 
 See `config/settings.user.json` for a reference template. Key pattern: `additionalDirectories` + `allowWrite` at user level covers all repos without per-project config.
 
+### Cloud Execution (CC Web)
+
+```bash
+# Fire-and-forget cloud sessions — no terminal keep-alive needed
+claude --remote "Run make validate" --repo github.com/qte77/Agents-eval
+claude --remote "Run make validate" --repo github.com/qte77/CABIO-test
+
+# Monitor from anywhere
+/tasks                         # In Claude Code terminal
+# Or: claude.ai/code, Claude mobile app
+```
+
+See `docs/cc-web-cloud-workflows.md` for the full local-to-cloud adaptation guide.
+
 ## Docs
 
+- `docs/cc-web-cloud-workflows.md` — Adapting polyforge for CC Web cloud execution
 - `docs/cross-repo-setup.md` — additionalDirectories + allowWrite pattern
 - `docs/sandbox-friction.md` — 4 friction points with mitigations
 - `docs/settings-consolidation.md` — DRY: user-level as single source of truth

--- a/docs/cc-web-cloud-workflows.md
+++ b/docs/cc-web-cloud-workflows.md
@@ -1,0 +1,152 @@
+# CC Web Cloud Workflows
+
+> Adapting polyforge's multi-repo parallel execution for Claude Code on the Web.
+
+## Context
+
+polyforge orchestrates local `claude -p` sessions across N repos via `cc-parallel.sh`. Claude Code on the Web (`claude.ai/code`) offers cloud-hosted, fire-and-forget execution with native GitHub integration. This document maps polyforge's local patterns to cloud equivalents and identifies gaps.
+
+## Local vs Cloud Execution Model
+
+| Aspect | Local (`claude -p`) | Cloud (`claude --remote`) |
+|---|---|---|
+| **Execution** | Local machine, blocking | Anthropic VM, fire-and-forget |
+| **Keep-alive** | Requires terminal/tmux | Not needed — survives disconnect |
+| **Output** | JSON to stdout | Git branch + PR on GitHub |
+| **Parallel** | Background processes + `wait` | Independent cloud sessions |
+| **Auth** | Local credentials | GitHub App (proxy-managed) |
+| **Monitoring** | PID tracking, log files | `/tasks`, web UI, mobile app |
+| **Budget control** | `--max-turns`, local cost tracking | Account rate limits only |
+| **Multi-repo context** | `additionalDirectories` | Not supported (1 repo/session) |
+
+## Mapping polyforge Scripts to Cloud
+
+### cc-parallel.sh (core adaptation)
+
+Replace `claude -p` with `claude --remote` for cloud execution:
+
+```bash
+#!/bin/bash
+# cc-parallel-web.sh — Fire-and-forget cloud sessions across repos
+source "$(dirname "$0")/repos.conf"
+
+PROMPT="${1:?Usage: $0 <prompt>}"
+
+for repo in "${REPOS[@]}"; do
+  name=$(basename "$repo")
+  # Derive GitHub org/repo from local path
+  github_repo="qte77/${name}"
+
+  echo "Launching cloud session: ${name}"
+  claude --remote "${PROMPT}" --repo "github.com/${github_repo}" &
+done
+
+echo ""
+echo "All sessions launched. Monitor via:"
+echo "  - /tasks (in Claude Code terminal)"
+echo "  - claude.ai/code (web UI)"
+echo "  - Claude mobile app"
+```
+
+**Key differences from local `cc-parallel.sh`**:
+
+- No `--output-format json` — results are commits on GitHub branches
+- No `wait $pid` + JSON collection — poll via `/tasks` or GitHub API
+- No `--max-turns` / `--max-budget` — cloud sessions use account rate limits
+- No `$OUTPUT_DIR` — results live as PRs on each repo
+
+### cc-status.sh (works as-is)
+
+The status dashboard uses `git` and `gh` CLI, which work regardless of whether tasks ran locally or in the cloud. Cloud sessions push branches, so `git fetch --all` + `gh pr list` captures results.
+
+### cc-repos.sh (not needed for cloud)
+
+tmux windows are unnecessary — cloud sessions don't require a terminal. Repurpose for monitoring:
+
+```bash
+# Monitor cloud sessions instead of launching tmux windows
+for repo in "${REPOS[@]}"; do
+  name=$(basename "$repo")
+  echo "=== ${name} ==="
+  gh pr list --repo "qte77/${name}" --label "claude-code" --limit 3
+done
+```
+
+### cc-credential-setup.sh (not needed for cloud)
+
+Cloud sessions authenticate via the Claude GitHub App — no local credential management required.
+
+## GitHub Actions Alternative (Durable Scheduling)
+
+For scheduled, unattended execution that survives everything:
+
+```yaml
+# .github/workflows/polyforge-validate.yml
+name: Polyforge Validate All Repos
+on:
+  schedule:
+    - cron: "0 9 * * 1-5"  # Weekdays at 9am
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    strategy:
+      matrix:
+        repo: [Agents-eval, CABIO-test, claude-code-research]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "Run make validate and report results"
+          claude_args: "--max-turns 5"
+```
+
+## Result Collection
+
+### Local (current)
+
+```
+$OUTPUT_DIR/
+├── Agents-eval.json
+├── CABIO-test.json
+└── cc-research.json
+```
+
+### Cloud (adapted)
+
+Results are GitHub PRs. Collect programmatically:
+
+```bash
+for repo in "${REPOS[@]}"; do
+  name=$(basename "$repo")
+  echo "=== ${name} ==="
+  gh pr list --repo "qte77/${name}" --state open --json number,title,createdAt \
+    --jq '.[] | "\(.number): \(.title) (\(.createdAt))"'
+done
+```
+
+## Known Limitations
+
+1. **One repo per session** — no cross-repo context sharing. Each `--remote` session sees only its own repo. [Feature request: #23627](https://github.com/anthropics/claude-code/issues/23627)
+2. **No budget/turn caps** — cloud sessions consume account rate limits, no per-session `--max-budget`
+3. **No JSON output** — results are git commits, not structured JSON. Parse via `gh` CLI
+4. **GitHub only** — no GitLab, Bitbucket, or local-only repos
+5. **Research preview** — `--remote` flag and CC Web are still in preview
+
+## Decision
+
+| Workflow | Use local (`cc-parallel.sh`) | Use cloud (`--remote`) | Use GitHub Actions |
+|---|---|---|---|
+| Quick validation | When repos are local | When on mobile/no terminal | Scheduled (daily/weekly) |
+| Security audit | Budget-constrained runs | Fire-and-forget, async review | Periodic automated audits |
+| Status check | Always (instant, no API cost) | N/A | N/A |
+| Long-running tasks | Needs tmux keep-alive | Built-in persistence | Durable, survives restarts |
+| Cross-repo context | Supported (additionalDirs) | Not supported | Not supported |
+
+## References
+
+- [Claude Code on the Web](https://code.claude.com/docs/en/claude-code-on-the-web)
+- [Claude Code GitHub Actions](https://code.claude.com/docs/en/github-actions)
+- [Scheduled Tasks](https://code.claude.com/docs/en/scheduled-tasks)
+- [Multi-repo feature request #23627](https://github.com/anthropics/claude-code/issues/23627)

--- a/docs/cc-web-cloud-workflows.md
+++ b/docs/cc-web-cloud-workflows.md
@@ -34,8 +34,8 @@ PROMPT="${1:?Usage: $0 <prompt>}"
 
 for repo in "${REPOS[@]}"; do
   name=$(basename "$repo")
-  # Derive GitHub org/repo from local path
-  github_repo="qte77/${name}"
+  # Derive GitHub org/repo from git remote
+  github_repo=$(git -C "$repo" remote get-url origin | sed 's#.*github.com[:/]##;s#\.git$##')
 
   echo "Launching cloud session: ${name}"
   claude --remote "${PROMPT}" --repo "github.com/${github_repo}" &
@@ -67,8 +67,9 @@ tmux windows are unnecessary — cloud sessions don't require a terminal. Repurp
 # Monitor cloud sessions instead of launching tmux windows
 for repo in "${REPOS[@]}"; do
   name=$(basename "$repo")
+  github_repo=$(git -C "$repo" remote get-url origin | sed 's#.*github.com[:/]##;s#\.git$##')
   echo "=== ${name} ==="
-  gh pr list --repo "qte77/${name}" --label "claude-code" --limit 3
+  gh pr list --repo "${github_repo}" --label "claude-code" --limit 3
 done
 ```
 
@@ -92,7 +93,7 @@ jobs:
   validate:
     strategy:
       matrix:
-        repo: [Agents-eval, CABIO-test, claude-code-research]
+        repo: [Agents-eval, CABIO-test, coding-agents-research]
     runs-on: ubuntu-latest
     steps:
       - uses: anthropics/claude-code-action@v1
@@ -121,7 +122,8 @@ Results are GitHub PRs. Collect programmatically:
 for repo in "${REPOS[@]}"; do
   name=$(basename "$repo")
   echo "=== ${name} ==="
-  gh pr list --repo "qte77/${name}" --state open --json number,title,createdAt \
+  github_repo=$(git -C "$repo" remote get-url origin | sed 's#.*github.com[:/]##;s#\.git$##')
+  gh pr list --repo "${github_repo}" --state open --json number,title,createdAt \
     --jq '.[] | "\(.number): \(.title) (\(.createdAt))"'
 done
 ```

--- a/docs/settings-consolidation.md
+++ b/docs/settings-consolidation.md
@@ -28,5 +28,5 @@ Remove `sandbox.filesystem` from project-level settings entirely. User-level `~/
 ### Applied To
 
 - `/workspaces/Agents-eval/.claude/settings.json` — removed redundant `sandbox.filesystem` block
-- `/workspaces/qte77/claude-code-research/.claude/settings.json` — removed redundant `sandbox.filesystem` block
+- `/workspaces/qte77/coding-agents-research/.claude/settings.json` — removed redundant `sandbox.filesystem` block
 - User-level `~/.claude/settings.json` — single source of truth for `additionalDirectories` + `allowWrite`

--- a/scripts/repos.conf
+++ b/scripts/repos.conf
@@ -3,7 +3,7 @@
 
 REPOS=(
   /workspaces/Agents-eval
-  /workspaces/qte77/claude-code-research
+  /workspaces/qte77/coding-agents-research
   /workspaces/qte77/CABIO-test
   /workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
   /workspaces/qte77/claude-code-utils-plugin


### PR DESCRIPTION
## Summary
- Add `docs/cc-web-cloud-workflows.md` mapping polyforge local patterns to CC Web cloud equivalents
- Add Cloud Execution section to README.md
- Rename `claude-code-research` → `coding-agents-research` in `repos.conf` and `settings-consolidation.md`
- Derive GitHub org/repo dynamically from git remote (no hardcoded paths)

## Test plan
- [ ] Verify all code examples use dynamic `git remote get-url` resolution
- [ ] Confirm README links work
- [ ] Confirm repos.conf points to renamed repo

Generated with Claude <noreply@anthropic.com>