### PR TITLE
feat(workspace): auto-open split terminal per repo on workspace load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` dynamically from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders and per-repo terminal tasks from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
 - tmux devcontainer feature for `cc-repos.sh` tmux sessions
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
 - `postAttachCommand`: replaced `code workspace.code-workspace` with user instruction echo
+- Workspace file now includes `runOn: folderOpen` shell tasks — opens one split terminal per repo automatically
 
 ### Fixed
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -8,16 +8,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/repos.conf"
 
 WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
+
 folders=""
+tasks=""
 for i in "${!REPOS[@]}"; do
+  path="${REPOS[$i]}"
+  name="${REPO_NAMES[$i]}"
+
   [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
+  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
+
+  # Shell task per repo — same group = side-by-side split terminals
+  [[ -n "$tasks" ]] && tasks+=","
+  tasks+=$'\n'"      {"
+  tasks+=$'\n'"        \"label\": \"${name}\","
+  tasks+=$'\n'"        \"type\": \"shell\","
+  tasks+=$'\n'"        \"command\": \"exec \$SHELL\","
+  tasks+=$'\n'"        \"options\": { \"cwd\": \"${path}\" },"
+  tasks+=$'\n'"        \"runOptions\": { \"runOn\": \"folderOpen\" },"
+  tasks+=$'\n'"        \"presentation\": { \"group\": \"repos\", \"reveal\": \"always\" },"
+  tasks+=$'\n'"        \"problemMatcher\": []"
+  tasks+=$'\n'"      }"
 done
 
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ]
+  ],
+  "settings": {
+    "task.allowAutomaticTasks": "on"
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [${tasks}
+    ]
+  }
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"


### PR DESCRIPTION
## Summary

- Generate VS Code `runOn: folderOpen` shell tasks in `workspace.code-workspace` — one per repo
- All tasks share `presentation.group: "repos"` so VS Code opens them as side-by-side split terminals
- `task.allowAutomaticTasks: "on"` in workspace settings skips the trust prompt

## How it works

When the workspace file is opened, VS Code automatically runs 7 shell tasks (one per repo in `repos.conf`). Each task `exec $SHELL` in its repo directory. The shared `group` causes VS Code to split them side-by-side in the terminal panel.

## Test plan

- [ ] `bash scripts/generate-workspace.sh` — workspace file includes `tasks` section
- [ ] Open `workspace.code-workspace` in VS Code — 7 split terminals appear, each cd'd to its repo
- [ ] Verify terminal labels match repo names from `repos.conf`

Generated with Claude <noreply@anthropic.com>