### PR TITLE
fix(devcontainer): remove orphaned cc-repos.sh from postAttachCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,5 @@
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
   "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
-  "postAttachCommand": "echo '→ Open workspace: Ctrl+Shift+P → Open Workspace from File → workspace.code-workspace' && bash scripts/cc-repos.sh"
+  "postAttachCommand": "echo '→ Open workspace: Ctrl+Shift+P → Open Workspace from File → workspace.code-workspace'"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders and per-repo terminal tasks from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders and per-repo split terminal tasks from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
-- tmux devcontainer feature for `cc-repos.sh` tmux sessions
+- tmux devcontainer feature for `cc-repos.sh` (CLI/SSH usage)
 
 ### Changed
 
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
-- `postAttachCommand`: replaced `code workspace.code-workspace` with user instruction echo
-- Workspace file now includes `runOn: folderOpen` shell tasks — opens one split terminal per repo automatically
+- `postAttachCommand`: replaced `code workspace.code-workspace` with user instruction echo; removed `cc-repos.sh` (VS Code terminals handled by workspace tasks)
 
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- tmux not available in devcontainer (missing feature)
+- Only one terminal on startup — workspace tasks now auto-open one split terminal per repo
 
 ## [0.0.1] - 2026-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` dynamically from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders and per-repo terminal tasks from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
 - tmux devcontainer feature for `cc-repos.sh` tmux sessions
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
 - `postAttachCommand`: replaced `code workspace.code-workspace` with user instruction echo
+- Workspace file now includes `runOn: folderOpen` shell tasks — opens one split terminal per repo automatically
 
 ### Fixed
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -8,16 +8,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/repos.conf"
 
 WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
+
 folders=""
+tasks=""
 for i in "${!REPOS[@]}"; do
+  path="${REPOS[$i]}"
+  name="${REPO_NAMES[$i]}"
+
   [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
+  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
+
+  # Shell task per repo — same group = side-by-side split terminals
+  [[ -n "$tasks" ]] && tasks+=","
+  tasks+=$'\n'"      {"
+  tasks+=$'\n'"        \"label\": \"${name}\","
+  tasks+=$'\n'"        \"type\": \"shell\","
+  tasks+=$'\n'"        \"command\": \"exec \$SHELL\","
+  tasks+=$'\n'"        \"options\": { \"cwd\": \"${path}\" },"
+  tasks+=$'\n'"        \"runOptions\": { \"runOn\": \"folderOpen\" },"
+  tasks+=$'\n'"        \"presentation\": { \"group\": \"repos\", \"reveal\": \"always\" },"
+  tasks+=$'\n'"        \"problemMatcher\": []"
+  tasks+=$'\n'"      }"
 done
 
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ]
+  ],
+  "settings": {
+    "task.allowAutomaticTasks": "on"
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [${tasks}
+    ]
+  }
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"


### PR DESCRIPTION
## Summary

- Remove `cc-repos.sh` from `postAttachCommand` — it created an orphaned tmux session in VS Code (workspace tasks handle split terminals now)
- Consolidate CHANGELOG: tmux = CLI/SSH tool, workspace tasks = VS Code terminals

## Test plan

- [ ] `grep cc-repos .devcontainer/devcontainer.json` — no matches
- [ ] Codespace rebuild: no tmux error in terminal, workspace tasks open split terminals

Generated with Claude <noreply@anthropic.com>