### PR TITLE
fix(devcontainer): move terminal tasks to .vscode/tasks.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
         "dotfiles.repository": "qte77/dotfiles",
         "dotfiles.installCommand": "install.sh",
         "dotfiles.targetPath": "~/dotfiles",
-        "makefile.configureOnOpen": false
+        "makefile.configureOnOpen": false,
+        "task.allowAutomaticTasks": "on"
       }
     }
   },
@@ -37,6 +38,5 @@
     "GH_PAT": "${localEnv:GH_PAT}",
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
-  "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
-  "postAttachCommand": "echo '→ Open workspace: Ctrl+Shift+P → Open Workspace from File → workspace.code-workspace'"
+  "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 *.log
 workspace.code-workspace
+.vscode/tasks.json
 # Sandbox device nodes (denyWithinAllow artifacts)
 HEAD
 hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders and per-repo split terminal tasks from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `.vscode/tasks.json` (split terminals) and `workspace.code-workspace` (sidebar folders) from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
 - tmux devcontainer feature for `cc-repos.sh` (CLI/SSH usage)
 
@@ -21,12 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
-- `postAttachCommand`: replaced `code workspace.code-workspace` with user instruction echo; removed `cc-repos.sh` (VS Code terminals handled by workspace tasks)
+- Terminal tasks moved from `workspace.code-workspace` to `.vscode/tasks.json` (auto-runs on folder open, no workspace file needed)
+- Removed `postAttachCommand` (terminals now handled by `.vscode/tasks.json` `runOn: folderOpen`)
 
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Only one terminal on startup — workspace tasks now auto-open one split terminal per repo
+- Only one terminal on startup — `.vscode/tasks.json` now auto-opens split terminals per repo on folder open
 
 ## [0.0.1] - 2026-03-17
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
-# Generate workspace.code-workspace from repos.conf
-# Ensures paths match the actual runtime environment
+# Generate .vscode/tasks.json (split terminals) and workspace.code-workspace (sidebar folders)
+# Both derived from repos.conf — single source of truth for repo paths
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
 source "${SCRIPT_DIR}/repos.conf"
 
-WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
+# --- .vscode/tasks.json (auto-opens split terminals on folder open) ---
+mkdir -p "${ROOT_DIR}/.vscode"
+TASKS_FILE="${ROOT_DIR}/.vscode/tasks.json"
 
-folders=""
 tasks=""
 for i in "${!REPOS[@]}"; do
   path="${REPOS[$i]}"
   name="${REPO_NAMES[$i]}"
 
-  [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
-
-  # Shell task per repo — same group = side-by-side split terminals
   [[ -n "$tasks" ]] && tasks+=","
   tasks+=$'\n'"      {"
   tasks+=$'\n'"        \"label\": \"${name}\","
@@ -31,18 +29,28 @@ for i in "${!REPOS[@]}"; do
   tasks+=$'\n'"      }"
 done
 
+cat > "$TASKS_FILE" <<EOF
+{
+  "version": "2.0.0",
+  "tasks": [${tasks}
+  ]
+}
+EOF
+echo "Generated $TASKS_FILE with ${#REPOS[@]} terminal tasks"
+
+# --- workspace.code-workspace (optional, for multi-root sidebar) ---
+WORKSPACE_FILE="${ROOT_DIR}/workspace.code-workspace"
+
+folders=""
+for i in "${!REPOS[@]}"; do
+  [[ -n "$folders" ]] && folders+=","
+  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
+done
+
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ],
-  "settings": {
-    "task.allowAutomaticTasks": "on"
-  },
-  "tasks": {
-    "version": "2.0.0",
-    "tasks": [${tasks}
-    ]
-  }
+  ]
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders (open manually for multi-root sidebar)"


### PR DESCRIPTION
## Summary

- Move split terminal tasks from `workspace.code-workspace` to `.vscode/tasks.json`
- VS Code auto-runs tasks on folder open — no workspace file, no `code` command, no new window
- `task.allowAutomaticTasks: "on"` in devcontainer settings skips trust prompt
- `postAttachCommand` removed (no longer needed)

## How it works

1. `onCreateCommand` → `clone-repos.sh` + `generate-workspace.sh`
2. `generate-workspace.sh` creates `.vscode/tasks.json` with `runOn: folderOpen` tasks
3. VS Code opens `/workspaces/polyforge` → reads `.vscode/tasks.json` → opens 7 split terminals automatically

## Test plan

- [ ] `bash scripts/generate-workspace.sh` — creates both `.vscode/tasks.json` and `workspace.code-workspace`
- [ ] Full rebuild: 7 split terminals auto-open, no `code` command runs
- [ ] `workspace.code-workspace` available for optional multi-root sidebar

Generated with Claude <noreply@anthropic.com>