### PR TITLE
fix(devcontainer): tasks in workspace file, postAttachCommand opens it

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,6 @@
     "GH_PAT": "${localEnv:GH_PAT}",
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
-  "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh"
+  "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
+  "postAttachCommand": "code workspace.code-workspace"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .env
 *.log
 workspace.code-workspace
-.vscode/tasks.json
 # Sandbox device nodes (denyWithinAllow artifacts)
 HEAD
 hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `.vscode/tasks.json` (split terminals) and `workspace.code-workspace` (sidebar folders) from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders, split terminal tasks, and settings from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
 - tmux devcontainer feature for `cc-repos.sh` (CLI/SSH usage)
 
@@ -21,13 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
-- Terminal tasks moved from `workspace.code-workspace` to `.vscode/tasks.json` (auto-runs on folder open, no workspace file needed)
-- Removed `postAttachCommand` (terminals now handled by `.vscode/tasks.json` `runOn: folderOpen`)
+- `postAttachCommand`: opens `workspace.code-workspace` (activates multi-root sidebar + terminal tasks)
 
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Only one terminal on startup — `.vscode/tasks.json` now auto-opens split terminals per repo on folder open
+- Only one terminal on startup — workspace `runOn: folderOpen` tasks auto-open split terminals per repo
 
 ## [0.0.1] - 2026-03-17
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
-# Generate .vscode/tasks.json (split terminals) and workspace.code-workspace (sidebar folders)
-# Both derived from repos.conf — single source of truth for repo paths
+# Generate workspace.code-workspace from repos.conf
+# Includes folders, split terminal tasks (runOn:folderOpen), and settings
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="${SCRIPT_DIR}/.."
 source "${SCRIPT_DIR}/repos.conf"
 
-# --- .vscode/tasks.json (auto-opens split terminals on folder open) ---
-mkdir -p "${ROOT_DIR}/.vscode"
-TASKS_FILE="${ROOT_DIR}/.vscode/tasks.json"
+WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
 
+folders=""
 tasks=""
 for i in "${!REPOS[@]}"; do
   path="${REPOS[$i]}"
   name="${REPO_NAMES[$i]}"
+
+  [[ -n "$folders" ]] && folders+=","
+  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
 
   [[ -n "$tasks" ]] && tasks+=","
   tasks+=$'\n'"      {"
@@ -29,28 +30,18 @@ for i in "${!REPOS[@]}"; do
   tasks+=$'\n'"      }"
 done
 
-cat > "$TASKS_FILE" <<EOF
-{
-  "version": "2.0.0",
-  "tasks": [${tasks}
-  ]
-}
-EOF
-echo "Generated $TASKS_FILE with ${#REPOS[@]} terminal tasks"
-
-# --- workspace.code-workspace (optional, for multi-root sidebar) ---
-WORKSPACE_FILE="${ROOT_DIR}/workspace.code-workspace"
-
-folders=""
-for i in "${!REPOS[@]}"; do
-  [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
-done
-
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ]
+  ],
+  "settings": {
+    "task.allowAutomaticTasks": "on"
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [${tasks}
+    ]
+  }
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders (open manually for multi-root sidebar)"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"


### PR DESCRIPTION
## Summary

- Put terminal tasks back in `workspace.code-workspace` (VS Code ignores `.vscode/tasks.json` in workspace mode)
- `postAttachCommand: "code workspace.code-workspace"` — earliest lifecycle with `code` CLI
- `generate-workspace.sh` outputs single file with folders + tasks + settings
- Removed `.vscode/tasks.json` generation (dead path in workspace mode)

## Flow

1. `onCreateCommand` → clone repos → generate `workspace.code-workspace` (folders + tasks + settings)
2. `postAttachCommand` → `code workspace.code-workspace` (activates workspace mode)
3. VS Code loads workspace → `runOn: folderOpen` tasks fire → 7 split terminals open

## Test plan

- [ ] Full rebuild: workspace loads, 7 split terminals auto-open
- [ ] Sidebar shows all repos in multi-root mode

Generated with Claude <noreply@anthropic.com>