### PR TITLE
fix(devcontainer): use postAttachCommand object format for terminals

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,5 +39,13 @@
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
   "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
-  "postAttachCommand": "code workspace.code-workspace"
+  "postAttachCommand": {
+    "Agents-eval": "cd /workspaces/Agents-eval 2>/dev/null && exec $SHELL || true",
+    "cc-research": "cd /workspaces/qte77/coding-agents-research 2>/dev/null && exec $SHELL || true",
+    "CABIO-test": "cd /workspaces/qte77/CABIO-test 2>/dev/null && exec $SHELL || true",
+    "ralph-template": "cd /workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template 2>/dev/null && exec $SHELL || true",
+    "cc-utils-plugin": "cd /workspaces/qte77/claude-code-utils-plugin 2>/dev/null && exec $SHELL || true",
+    "deepvariant": "cd /workspaces/qte77/deepvariant-linux-arm64 2>/dev/null && exec $SHELL || true",
+    "polyforge": "exec $SHELL"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders, split terminal tasks, and settings from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` (folders only) from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
 - tmux devcontainer feature for `cc-repos.sh` (CLI/SSH usage)
 
@@ -21,12 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
-- `postAttachCommand`: opens `workspace.code-workspace` (activates multi-root sidebar + terminal tasks)
+- `postAttachCommand`: object format with one terminal per repo (no workspace reload)
 
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Only one terminal on startup — workspace `runOn: folderOpen` tasks auto-open split terminals per repo
+- Only one terminal on startup — `postAttachCommand` object format opens one terminal per repo
 
 ## [0.0.1] - 2026-03-17
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Generate workspace.code-workspace from repos.conf
-# Includes folders, split terminal tasks (runOn:folderOpen), and settings
+# Generate workspace.code-workspace from repos.conf (folders only)
+# Open manually for multi-root sidebar: Ctrl+Shift+P → Open Workspace from File
+# Terminals are handled by postAttachCommand object format in devcontainer.json
 
 set -euo pipefail
 
@@ -10,38 +11,15 @@ source "${SCRIPT_DIR}/repos.conf"
 WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
 
 folders=""
-tasks=""
 for i in "${!REPOS[@]}"; do
-  path="${REPOS[$i]}"
-  name="${REPO_NAMES[$i]}"
-
   [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
-
-  [[ -n "$tasks" ]] && tasks+=","
-  tasks+=$'\n'"      {"
-  tasks+=$'\n'"        \"label\": \"${name}\","
-  tasks+=$'\n'"        \"type\": \"shell\","
-  tasks+=$'\n'"        \"command\": \"exec \$SHELL\","
-  tasks+=$'\n'"        \"options\": { \"cwd\": \"${path}\" },"
-  tasks+=$'\n'"        \"runOptions\": { \"runOn\": \"folderOpen\" },"
-  tasks+=$'\n'"        \"presentation\": { \"group\": \"repos\", \"reveal\": \"always\" },"
-  tasks+=$'\n'"        \"problemMatcher\": []"
-  tasks+=$'\n'"      }"
+  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
 done
 
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ],
-  "settings": {
-    "task.allowAutomaticTasks": "on"
-  },
-  "tasks": {
-    "version": "2.0.0",
-    "tasks": [${tasks}
-    ]
-  }
+  ]
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders"


### PR DESCRIPTION
## Summary

- `postAttachCommand` as object: each key creates a VS Code terminal tab (one per repo)
- Removed `code workspace.code-workspace` (caused disruptive reload, killed terminals)
- Simplified `generate-workspace.sh` to folders only (no tasks — terminals handled by devcontainer)
- Workspace file kept for optional manual multi-root sidebar use

## Why

- `runOn: folderOpen` tasks don't fire reliably in Codespaces
- `code workspace.code-workspace` reloads VS Code, killing any terminals that started
- Devcontainer spec object format is the guaranteed way to create multiple terminals

## Test plan

- [ ] Full rebuild: 7 terminal tabs auto-open (one per repo)
- [ ] No VS Code reload on attach
- [ ] Optional: open workspace.code-workspace manually for multi-root sidebar

Generated with Claude <noreply@anthropic.com>