### PR TITLE
fix(devcontainer): use tmux for terminals, restore sidebar workspace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,13 +39,5 @@
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
   "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
-  "postAttachCommand": {
-    "Agents-eval": "cd /workspaces/Agents-eval 2>/dev/null && exec $SHELL || true",
-    "cc-research": "cd /workspaces/qte77/coding-agents-research 2>/dev/null && exec $SHELL || true",
-    "CABIO-test": "cd /workspaces/qte77/CABIO-test 2>/dev/null && exec $SHELL || true",
-    "ralph-template": "cd /workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template 2>/dev/null && exec $SHELL || true",
-    "cc-utils-plugin": "cd /workspaces/qte77/claude-code-utils-plugin 2>/dev/null && exec $SHELL || true",
-    "deepvariant": "cd /workspaces/qte77/deepvariant-linux-arm64 2>/dev/null && exec $SHELL || true",
-    "polyforge": "exec $SHELL"
-  }
+  "postAttachCommand": "code workspace.code-workspace; bash scripts/cc-repos.sh"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
-- `postAttachCommand`: object format with one terminal per repo (no workspace reload)
+- `postAttachCommand`: opens workspace file (multi-root sidebar) + tmux session (one window per repo via `cc-repos.sh`)
 
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Only one terminal on startup — `postAttachCommand` object format opens one terminal per repo
+- Only one terminal on startup — tmux session with per-repo windows (Ctrl-b + number to switch)
 
 ## [0.0.1] - 2026-03-17
 


### PR DESCRIPTION
## Summary

- Restore `code workspace.code-workspace` for multi-root sidebar
- Use `cc-repos.sh` tmux session for per-repo terminals (Ctrl-b + number)
- Object format `postAttachCommand` didn't create visible terminals in Codespaces

## Flow

1. First attach: `code` opens workspace (reload), tmux dies (expected)
2. Re-attach after reload: `code` no-op, `cc-repos.sh` creates tmux session
3. User navigates repos via Ctrl-b + number or Ctrl-b + w

## Important

Use **Full Rebuild** (`Ctrl+Shift+P → Codespaces: Full Rebuild Container`) — regular rebuild uses cached devcontainer config.

## Test plan

- [ ] Full rebuild: sidebar shows all repos, tmux session in terminal
- [ ] Ctrl-b + w shows all repo windows in tmux

Generated with Claude <noreply@anthropic.com>