### PR TITLE
fix(workspace): add isBackground + dependsOn for auto-open terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` (folders only) from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders, `isBackground` terminal tasks, and compound `dependsOn` grouping from `repos.conf`
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
 - tmux devcontainer feature for `cc-repos.sh` (CLI/SSH usage)
 
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Only one terminal on startup — tmux session with per-repo windows (Ctrl-b + number to switch)
+- Only one terminal on startup — workspace `isBackground` tasks with compound `dependsOn` auto-open split terminals per repo
 
 ## [0.0.1] - 2026-03-17
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Generate workspace.code-workspace from repos.conf (folders only)
-# Open manually for multi-root sidebar: Ctrl+Shift+P → Open Workspace from File
-# Terminals are handled by postAttachCommand object format in devcontainer.json
+# Generate workspace.code-workspace from repos.conf
+# Includes folders, auto-open terminal tasks, and settings
+# Pattern: https://jackharner.com/blog/auto-open-terminals-vs-code-workspace/
 
 set -euo pipefail
 
@@ -11,15 +11,49 @@ source "${SCRIPT_DIR}/repos.conf"
 WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
 
 folders=""
+tasks=""
+depends=""
 for i in "${!REPOS[@]}"; do
+  path="${REPOS[$i]}"
+  name="${REPO_NAMES[$i]}"
+
   [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
+  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
+
+  [[ -n "$tasks" ]] && tasks+=","
+  tasks+=$'\n'"      {"
+  tasks+=$'\n'"        \"label\": \"${name}\","
+  tasks+=$'\n'"        \"type\": \"shell\","
+  tasks+=$'\n'"        \"command\": \"/bin/bash\","
+  tasks+=$'\n'"        \"isBackground\": true,"
+  tasks+=$'\n'"        \"options\": { \"cwd\": \"${path}\" },"
+  tasks+=$'\n'"        \"runOptions\": { \"runOn\": \"folderOpen\" },"
+  tasks+=$'\n'"        \"presentation\": { \"group\": \"repos\", \"reveal\": \"always\" },"
+  tasks+=$'\n'"        \"problemMatcher\": []"
+  tasks+=$'\n'"      }"
+
+  [[ -n "$depends" ]] && depends+=", "
+  depends+="\"${name}\""
 done
 
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ]
+  ],
+  "settings": {
+    "task.allowAutomaticTasks": "on"
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Open All Terminals",
+        "dependsOn": [${depends}],
+        "runOptions": { "runOn": "folderOpen" },
+        "problemMatcher": []
+      },${tasks}
+    ]
+  }
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"


### PR DESCRIPTION
## Summary

Previous workspace tasks were missing three pieces that the [proven pattern](https://jackharner.com/blog/auto-open-terminals-vs-code-workspace/) requires:

1. `isBackground: true` — marks tasks as background (non-blocking)
2. Compound parent task with `dependsOn` — groups all terminals
3. `/bin/bash` instead of `exec $SHELL` — explicit, reliable

## Flow

1. `onCreateCommand` → clone repos → `generate-workspace.sh` (workspace file with tasks)
2. `postAttachCommand` → `code workspace.code-workspace` (opens workspace + triggers `runOn: folderOpen`)
3. Workspace opens → compound task fires → 7 background terminal tasks start

## Test plan

- [ ] Full rebuild: sidebar + 7 split terminals auto-open
- [ ] Terminals labeled per repo name

Generated with Claude <noreply@anthropic.com>