### PR TITLE
fix(devcontainer): drop code command, use tmux for terminals

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,8 +29,7 @@
         "dotfiles.repository": "qte77/dotfiles",
         "dotfiles.installCommand": "install.sh",
         "dotfiles.targetPath": "~/dotfiles",
-        "makefile.configureOnOpen": false,
-        "task.allowAutomaticTasks": "on"
+        "makefile.configureOnOpen": false
       }
     }
   },
@@ -39,5 +38,5 @@
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
   "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
-  "postAttachCommand": "code workspace.code-workspace; bash scripts/cc-repos.sh"
+  "postAttachCommand": "bash scripts/cc-repos.sh"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` with folders, `isBackground` terminal tasks, and compound `dependsOn` grouping from `repos.conf`
+- `scripts/generate-workspace.sh`: generates `workspace.code-workspace` (folders only) from `repos.conf`; VS Code auto-detects for multi-root sidebar
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
-- tmux devcontainer feature for `cc-repos.sh` (CLI/SSH usage)
+- tmux devcontainer feature + `postAttachCommand` runs `cc-repos.sh` for per-repo tmux windows
 
 ### Changed
 
 - `scripts/repos.conf`: dynamic `POLYFORGE_ROOT` detection (works at any checkout path)
 - `workspace.code-workspace` is now generated (added to `.gitignore`)
-- `postAttachCommand`: opens workspace file (multi-root sidebar) + tmux session (one window per repo via `cc-repos.sh`)
+
+### Removed
+
+- `code workspace.code-workspace` from `postAttachCommand` (spawned new VS Code instance; sidebar loads automatically without it)
+- Workspace tasks (`runOn: folderOpen`) — do not fire in Codespaces
 
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Only one terminal on startup — workspace `isBackground` tasks with compound `dependsOn` auto-open split terminals per repo
+- Multiple terminals on startup via tmux (`cc-repos.sh`, Ctrl-b + number to switch)
 
 ## [0.0.1] - 2026-03-17
 

--- a/scripts/generate-workspace.sh
+++ b/scripts/generate-workspace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Generate workspace.code-workspace from repos.conf
-# Includes folders, auto-open terminal tasks, and settings
-# Pattern: https://jackharner.com/blog/auto-open-terminals-vs-code-workspace/
+# Generate workspace.code-workspace from repos.conf (folders only)
+# VS Code auto-detects this file for multi-root sidebar
+# Terminals handled by tmux via cc-repos.sh in postAttachCommand
 
 set -euo pipefail
 
@@ -11,49 +11,15 @@ source "${SCRIPT_DIR}/repos.conf"
 WORKSPACE_FILE="${SCRIPT_DIR}/../workspace.code-workspace"
 
 folders=""
-tasks=""
-depends=""
 for i in "${!REPOS[@]}"; do
-  path="${REPOS[$i]}"
-  name="${REPO_NAMES[$i]}"
-
   [[ -n "$folders" ]] && folders+=","
-  folders+=$'\n'"    { \"path\": \"${path}\", \"name\": \"${name}\" }"
-
-  [[ -n "$tasks" ]] && tasks+=","
-  tasks+=$'\n'"      {"
-  tasks+=$'\n'"        \"label\": \"${name}\","
-  tasks+=$'\n'"        \"type\": \"shell\","
-  tasks+=$'\n'"        \"command\": \"/bin/bash\","
-  tasks+=$'\n'"        \"isBackground\": true,"
-  tasks+=$'\n'"        \"options\": { \"cwd\": \"${path}\" },"
-  tasks+=$'\n'"        \"runOptions\": { \"runOn\": \"folderOpen\" },"
-  tasks+=$'\n'"        \"presentation\": { \"group\": \"repos\", \"reveal\": \"always\" },"
-  tasks+=$'\n'"        \"problemMatcher\": []"
-  tasks+=$'\n'"      }"
-
-  [[ -n "$depends" ]] && depends+=", "
-  depends+="\"${name}\""
+  folders+=$'\n'"    { \"path\": \"${REPOS[$i]}\", \"name\": \"${REPO_NAMES[$i]}\" }"
 done
 
 cat > "$WORKSPACE_FILE" <<EOF
 {
   "folders": [${folders}
-  ],
-  "settings": {
-    "task.allowAutomaticTasks": "on"
-  },
-  "tasks": {
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "Open All Terminals",
-        "dependsOn": [${depends}],
-        "runOptions": { "runOn": "folderOpen" },
-        "problemMatcher": []
-      },${tasks}
-    ]
-  }
+  ]
 }
 EOF
-echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders and terminal tasks"
+echo "Generated $WORKSPACE_FILE with ${#REPOS[@]} folders"


### PR DESCRIPTION
## Summary

- Remove `code workspace.code-workspace` — spawns new VS Code instance; sidebar loads automatically without it
- Remove workspace tasks — `runOn: folderOpen` does not fire in Codespaces (tested multiple configurations)
- `postAttachCommand: "bash scripts/cc-repos.sh"` — tmux session with per-repo windows
- Simplify `generate-workspace.sh` to folders only

## Learnings

- VS Code Codespaces auto-detects `.code-workspace` files for multi-root sidebar
- `runOn: folderOpen` tasks do not fire in Codespaces (with or without `isBackground`, `dependsOn`, `task.allowAutomaticTasks`)
- `postAttachCommand` object format does not create visible terminal tabs in Codespaces

## Test plan

- [ ] Full rebuild: sidebar shows all repos, tmux session in terminal
- [ ] No new VS Code instance spawned
- [ ] Ctrl-b + w shows all repo windows

Generated with Claude <noreply@anthropic.com>