### PR TITLE
fix(devcontainer): set tmux as default VS Code terminal profile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,15 @@
         "dotfiles.repository": "qte77/dotfiles",
         "dotfiles.installCommand": "install.sh",
         "dotfiles.targetPath": "~/dotfiles",
-        "makefile.configureOnOpen": false
+        "makefile.configureOnOpen": false,
+        "terminal.integrated.profiles.linux": {
+          "tmux": {
+            "path": "bash",
+            "args": ["-c", "tmux new-session -A -s repos"],
+            "icon": "terminal-tmux"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "tmux"
       }
     }
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/generate-workspace.sh`: generates `workspace.code-workspace` (folders only) from `repos.conf`; VS Code auto-detects for multi-root sidebar
 - WakaTime API key non-interactive setup via `WAKATIME_API_KEY` Codespace secret
-- tmux devcontainer feature + `postAttachCommand` runs `cc-repos.sh` for per-repo tmux windows
+- tmux as default VS Code terminal profile (`terminal.integrated.defaultProfile.linux`)
+- `postAttachCommand` runs `cc-repos.sh` to create tmux session with per-repo windows
 
 ### Changed
 
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sidebar folders not loading when polyforge is the main Codespace repo (path mismatch)
-- Multiple terminals on startup via tmux (`cc-repos.sh`, Ctrl-b + number to switch)
+- Multiple terminals on startup — tmux is default terminal profile; every terminal opens into per-repo tmux session (Ctrl-b + number to switch)
 
 ## [0.0.1] - 2026-03-17
 


### PR DESCRIPTION
## Summary

- Set tmux as default terminal profile via `terminal.integrated.defaultProfile.linux`
- Profile uses `tmux new-session -A -s repos` — auto-attaches to the session created by `cc-repos.sh`
- Every terminal opened in VS Code (Ctrl+`, split, etc.) lands directly in the tmux repos session

## How it works

1. `postAttachCommand` runs `cc-repos.sh` → creates tmux session with 7 windows (one per repo)
2. VS Code default terminal is tmux → every new terminal auto-attaches to that session
3. Navigate: Ctrl-b + number, Ctrl-b + w (window list), Ctrl-b + n/p (next/prev)

## Test plan

- [ ] Full rebuild: terminal opens into tmux automatically
- [ ] Ctrl-b + w shows all repo windows
- [ ] New terminal (Ctrl+`) also attaches to tmux session

Generated with Claude <noreply@anthropic.com>