### PR TITLE
fix(devcontainer): stop generating workspace.code-workspace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,6 +45,6 @@
     "GH_PAT": "${localEnv:GH_PAT}",
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
-  "onCreateCommand": "bash .devcontainer/clone-repos.sh && bash scripts/generate-workspace.sh",
+  "onCreateCommand": "bash .devcontainer/clone-repos.sh",
   "postAttachCommand": "bash scripts/cc-repos.sh"
 }


### PR DESCRIPTION
## Summary

Codespaces auto-detects `.code-workspace` files at the repo root and runs `code workspace.code-workspace`, spawning a new VS Code window. Sidebar multi-root loads without the file. Remove `generate-workspace.sh` from `onCreateCommand`.

## Test plan

- [ ] Full rebuild: no `code workspace.code-workspace` in terminal, no new window
- [ ] Sidebar still shows repos (if not, multi-root was dependent on the file)

Generated with Claude <noreply@anthropic.com>