### PR TITLE
fix(devcontainer): prevent recovery mode from script failures

### DIFF
--- a/.devcontainer/clone-repos.sh
+++ b/.devcontainer/clone-repos.sh
@@ -2,7 +2,7 @@
 # Clone all managed repos into the workspace
 # Derives GitHub owner/repo from repos.conf paths — single source of truth
 
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../scripts/repos.conf"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,5 +46,5 @@
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
   "onCreateCommand": "bash .devcontainer/clone-repos.sh",
-  "postAttachCommand": "bash scripts/cc-repos.sh"
+  "postAttachCommand": "bash scripts/cc-repos.sh || true"
 }


### PR DESCRIPTION
Remove set -e from clone-repos.sh, add || true to postAttachCommand