### PR TITLE
fix(devcontainer): remove tmux default terminal profile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,15 +29,7 @@
         "dotfiles.repository": "qte77/dotfiles",
         "dotfiles.installCommand": "install.sh",
         "dotfiles.targetPath": "~/dotfiles",
-        "makefile.configureOnOpen": false,
-        "terminal.integrated.profiles.linux": {
-          "tmux": {
-            "path": "bash",
-            "args": ["-c", "tmux new-session -A -s repos"],
-            "icon": "terminal-tmux"
-          }
-        },
-        "terminal.integrated.defaultProfile.linux": "tmux"
+        "makefile.configureOnOpen": false
       }
     }
   },


### PR DESCRIPTION
tmux as defaultProfile.linux crashes VS Code workbench on startup. Keep tmux installed for manual use.