### PR TITLE
fix(devcontainer): robust onCreateCommand, restore workspace generation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,6 @@
     "GH_PAT": "${localEnv:GH_PAT}",
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
-  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y tmux && bash .devcontainer/clone-repos.sh",
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y tmux; bash .devcontainer/clone-repos.sh; bash scripts/generate-workspace.sh",
   "postAttachCommand": "bash scripts/cc-repos.sh || true"
 }


### PR DESCRIPTION
Use ; instead of && so apt-get failure does not block clone-repos and workspace generation.