### PR TITLE
fix(devcontainer): skip apt-get update (causes timeout)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,6 @@
     "GH_PAT": "${localEnv:GH_PAT}",
     "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
   },
-  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y tmux; bash .devcontainer/clone-repos.sh; bash scripts/generate-workspace.sh",
+  "onCreateCommand": "sudo apt-get install -y tmux 2>/dev/null; bash .devcontainer/clone-repos.sh; bash scripts/generate-workspace.sh",
   "postAttachCommand": "bash scripts/cc-repos.sh || true"
 }


### PR DESCRIPTION
Remove apt-get update from onCreateCommand — slow enough to cause deadline exceeded.