### PR TITLE
fix: track workspace.code-workspace for Codespaces auto-detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .env
 *.log
-workspace.code-workspace
 # Sandbox device nodes (denyWithinAllow artifacts)
 HEAD
 hooks

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,11 @@
+{
+  "folders": [
+    { "path": "/workspaces/Agents-eval", "name": "Agents-eval" },
+    { "path": "/workspaces/qte77/coding-agents-research", "name": "cc-research" },
+    { "path": "/workspaces/qte77/CABIO-test", "name": "CABIO-test" },
+    { "path": "/workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template", "name": "ralph-template" },
+    { "path": "/workspaces/qte77/claude-code-utils-plugin", "name": "cc-utils-plugin" },
+    { "path": "/workspaces/qte77/deepvariant-linux-arm64", "name": "deepvariant" },
+    { "path": "/workspaces/polyforge", "name": "polyforge" }
+  ]
+}


### PR DESCRIPTION
Codespaces only auto-detects TRACKED .code-workspace files. Untracking broke multi-root sidebar.