### PR TITLE
chore: standardize repo scaffold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
+  },
+  "enabledPlugins": {
+    "commit-helper@qte77-claude-code-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1. Run `...`
+2. ...
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error traces if applicable -->
+
+## Environment
+
+- OS/Runner:
+- Version:
+
+## Additional Context
+
+<!-- Screenshots, logs, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Ask a question not covered by the documentation
+title: ''
+labels: question
+assignees: ''
+---
+
+**Have you checked the docs?**
+
+- [ ] README.md
+
+## Question
+
+<!-- Your question here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Summary
+
+<!-- Brief description of what this PR does and why -->
+
+Closes <!-- #issue-number or N/A -->
+
+## Type of Change
+
+<!-- Check all that apply. Commit type must match conventional commits: feat|fix|build|chore|ci|docs|style|refactor|perf|revert|test -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — no functional change
+- [ ] `test` — test additions or fixes
+- [ ] `ci` — CI/CD changes
+- [ ] `build` — build system or dependency changes
+- [ ] `perf` — performance improvement
+- [ ] `style` — formatting, whitespace (no logic change)
+- [ ] `revert` — reverts a previous commit
+- [ ] `chore` — tooling, config, maintenance
+- [ ] **Breaking change** — add `!` after commit type
+
+## Self-Review
+
+- [ ] I have reviewed my own diff and removed debug/dead code
+- [ ] Commit messages follow conventional commits format
+
+## Testing
+
+- [ ] Tests pass locally
+- [ ] CI workflows pass
+
+## Security
+
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] No new injection vectors in workflow `run:` steps

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,38 @@
+#<--- 72 characters --------------------------------------------------->
+#
+# Conventional Commits, semantic commit messages for humans and machines
+# https://www.conventionalcommits.org/en/v1.0.0/
+# Lint your conventional commits
+# https://github.com/conventional-changelog/commitlint/tree/master/%40 \
+#	commitlint/config-conventional
+# Common types can be (based on Angular convention)
+# build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+# https://github.com/conventional-changelog/commitlint/tree/master/%40
+# Footer
+# https://git-scm.com/docs/git-interpret-trailers
+#
+#<--- pattern --------------------------------------------------------->
+#
+# <feat|fix|build|chore|ci|docs|style|refactor|perf|test>[(Scope)][!]: \
+#	<description>
+# short description: <type>[(<scope>)]: <subject>
+#
+# ! after scope in header indicates breaking change
+#
+# [optional body]
+#
+# - with bullets points
+#
+# [optional footer(s)]
+#
+# [BREAKING CHANGE:, Refs:, Resolves:, Addresses:, Reviewed by:]
+#
+#<--- usage ----------------------------------------------------------->
+#
+# Set locally (in the repository)
+# `git config commit.template .gitmessage`
+#
+# Set globally
+# `git config --global commit.template .gitmessage`
+#
+#<--- 72 characters --------------------------------------------------->

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2026 qte77
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/polyforge/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.


### PR DESCRIPTION
## Summary

Standardize repository scaffold to match the qte77 org-wide pattern.

## Changes

- `.gitmessage` — conventional commits template
- `.claude/settings.json` — attribution config + commit-helper plugin
- `SECURITY.md` — GitHub Security Advisories reporting link
- `.github/PULL_REQUEST_TEMPLATE.md` — conventional commits PR checklist
- `.github/ISSUE_TEMPLATE/` — bug report + question templates
- CodeQL workflow (where applicable)
- Dependabot config (where applicable)
- `LICENSE` (BSD-3-Clause, where missing)
- `.gitignore` (where missing / fixed)

Generated with Claude <noreply@anthropic.com>