### PR TITLE
chore: rename CABIO-test to RAPID-spec-forge across configs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,68 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+      {
+        "label": "Agents-eval",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/Agents-eval" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      },
+      {
+        "label": "cc-research",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/qte77/ai-agents-research" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      },
+      {
+        "label": "RAPID-spec-forge",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/qte77/RAPID-spec-forge" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      },
+      {
+        "label": "ralph-template",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      },
+      {
+        "label": "cc-utils-plugin",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/qte77/claude-code-utils-plugin" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      },
+      {
+        "label": "deepvariant",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/qte77/deepvariant-linux-arm64" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      },
+      {
+        "label": "polyforge",
+        "type": "shell",
+        "command": "exec $SHELL",
+        "options": { "cwd": "/workspaces/qte77/polyforge" },
+        "runOptions": { "runOn": "folderOpen" },
+        "presentation": { "group": "repos", "reveal": "always" },
+        "problemMatcher": []
+      }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See `config/settings.user.json` for a reference template. Key pattern: `addition
 ```bash
 # Fire-and-forget cloud sessions — no terminal keep-alive needed
 claude --remote "Run make validate" --repo github.com/qte77/Agents-eval
-claude --remote "Run make validate" --repo github.com/qte77/CABIO-test
+claude --remote "Run make validate" --repo github.com/qte77/RAPID-spec-forge
 
 # Monitor from anywhere
 /tasks                         # In Claude Code terminal

--- a/docs/cc-web-cloud-workflows.md
+++ b/docs/cc-web-cloud-workflows.md
@@ -93,7 +93,7 @@ jobs:
   validate:
     strategy:
       matrix:
-        repo: [Agents-eval, CABIO-test, coding-agents-research]
+        repo: [Agents-eval, RAPID-spec-forge, ai-agents-research]
     runs-on: ubuntu-latest
     steps:
       - uses: anthropics/claude-code-action@v1
@@ -110,7 +110,7 @@ jobs:
 ```
 $OUTPUT_DIR/
 ├── Agents-eval.json
-├── CABIO-test.json
+├── RAPID-spec-forge.json
 └── cc-research.json
 ```
 

--- a/scripts/cc-parallel.sh
+++ b/scripts/cc-parallel.sh
@@ -15,7 +15,7 @@
 #   security    — Audit for security issues
 #
 # Examples:
-#   ./cc-parallel.sh "Run make validate" /workspaces/Agents-eval /workspaces/qte77/CABIO-test
+#   ./cc-parallel.sh "Run make validate" /workspaces/Agents-eval /workspaces/qte77/RAPID-spec-forge
 #   ./cc-parallel.sh --preset validate
 #   ./cc-parallel.sh --max-budget 1.0 "Check for TODO comments" /workspaces/Agents-eval
 

--- a/scripts/repos.conf
+++ b/scripts/repos.conf
@@ -7,8 +7,8 @@ POLYFORGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 REPOS=(
   /workspaces/Agents-eval
-  /workspaces/qte77/coding-agents-research
-  /workspaces/qte77/CABIO-test
+  /workspaces/qte77/ai-agents-research
+  /workspaces/qte77/RAPID-spec-forge
   /workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
   /workspaces/qte77/claude-code-utils-plugin
   /workspaces/qte77/deepvariant-linux-arm64
@@ -19,7 +19,7 @@ REPOS=(
 REPO_NAMES=(
   Agents-eval
   cc-research
-  CABIO-test
+  RAPID-spec-forge
   ralph-template
   cc-utils-plugin
   deepvariant

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,8 +1,8 @@
 {
   "folders": [
     { "path": "/workspaces/Agents-eval", "name": "Agents-eval" },
-    { "path": "/workspaces/qte77/coding-agents-research", "name": "cc-research" },
-    { "path": "/workspaces/qte77/CABIO-test", "name": "CABIO-test" },
+    { "path": "/workspaces/qte77/ai-agents-research", "name": "cc-research" },
+    { "path": "/workspaces/qte77/RAPID-spec-forge", "name": "RAPID-spec-forge" },
     { "path": "/workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template", "name": "ralph-template" },
     { "path": "/workspaces/qte77/claude-code-utils-plugin", "name": "cc-utils-plugin" },
     { "path": "/workspaces/qte77/deepvariant-linux-arm64", "name": "deepvariant" },


### PR DESCRIPTION
## Summary

- Rename CABIO-test → RAPID-spec-forge in all polyforge configs
- Also rename coding-agents-research → ai-agents-research
- Files: repos.conf, workspace.code-workspace, tasks.json, README.md, cc-parallel.sh, cc-web-cloud-workflows.md

## Test plan

- [ ] Zero CABIO-test references in active config files
- [ ] Zero coding-agents-research references in active config files

Generated with Claude <noreply@anthropic.com>