### PR TITLE
fix(devcontainer): seed ~/.wakatime.cfg with tracking-safe defaults

### DIFF
--- a/.devcontainer/clone-repos.sh
+++ b/.devcontainer/clone-repos.sh
@@ -29,7 +29,19 @@ echo "Done. $(ls -d "${REPOS[@]}" 2>/dev/null | wc -l)/${#REPOS[@]} repos availa
 
 # Seed WakaTime config from Codespace secret (prevents interactive prompt)
 if [[ -n "${WAKATIME_API_KEY:-}" && ! -f "$HOME/.wakatime.cfg" ]]; then
-  printf '[settings]\napi_key = %s\n' "$WAKATIME_API_KEY" > "$HOME/.wakatime.cfg"
+  cat > "$HOME/.wakatime.cfg" <<EOF
+[settings]
+api_key = ${WAKATIME_API_KEY}
+api_url = https://api.wakatime.com/api/v1
+heartbeat_rate_limit_seconds = 120
+# disabled: silently blocks all tracking in repos without .wakatime-project
+# include_only_with_project_file = true
+# disabled: drops heartbeats for any project WakaTime can't resolve a name for
+# exclude_unknown_project = true
+offline = true
+status_bar_enabled = true
+status_bar_coding_activity = true
+EOF
   echo "WakaTime: config seeded from WAKATIME_API_KEY"
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `clone-repos.sh`: seed `~/.wakatime.cfg` with tracking-safe defaults — `include_only_with_project_file` and `exclude_unknown_project` silently block all heartbeats when `true` (closes #30)
+
 ### Added
 
 - `scripts/generate-workspace.sh`: generates `workspace.code-workspace` (folders only) from `repos.conf` for multi-root sidebar


### PR DESCRIPTION
## Summary

- Seeds `~/.wakatime.cfg` with full validated config instead of bare `api_key` only
- Explicitly disables `include_only_with_project_file` and `exclude_unknown_project` — both silently block all heartbeats when `true`, no error shown
- Validated on live Codespace 2026-03-25

## Test plan

- [ ] Rebuild Codespace — `~/.wakatime.cfg` present without interactive prompt
- [ ] Edit any file in a managed repo — WakaTime status bar updates within 2 min
- [ ] `cat ~/.wakatime.cfg` — both problematic settings are commented out
- [ ] Existing `~/.wakatime.cfg` is not overwritten (guard: `\! -f`)

Closes #30

Generated with Claude <noreply@anthropic.com>