### PR TITLE
feat: add self-evolving ralphy offspring repos

### DIFF
--- a/scripts/repos.conf
+++ b/scripts/repos.conf
@@ -12,6 +12,8 @@ REPOS=(
   /workspaces/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
   /workspaces/qte77/claude-code-utils-plugin
   /workspaces/qte77/deepvariant-linux-arm64
+  /workspaces/qte77/learnings-ralphy
+  /workspaces/qte77/research-ralphy
   "${POLYFORGE_ROOT}"
 )
 
@@ -23,5 +25,7 @@ REPO_NAMES=(
   ralph-template
   cc-utils-plugin
   deepvariant
+  learnings-ralphy
+  research-ralphy
   polyforge
 )


### PR DESCRIPTION
## Summary
- Add `learnings-ralphy` and `research-ralphy` to `scripts/repos.conf`
- Two self-evolving ralph offspring using git submodule pattern
- learnings-ralphy: distills LEARNINGS.md + AGENT_LEARNINGS.md patterns into TDD improvements (Thu cron)
- research-ralphy: turns ai-agents-research discoveries into implementations (Wed cron)
- Both consume CC session data (plans, tasks, teams, stats) via compound learning
- Ralph self-improvement loop closes the feedback cycle (Fri cron)

## Architecture
```
REGISTRY (gha-repo-index) → OBSERVE (monitors) → TRANSFORM (ai-changelog)
→ ORCHESTRATE (issue-sync) → DISTRIBUTE (mirror) → IMPLEMENT (ralphys)
```

## Dependencies
- Ralphy repos (`qte77/learnings-ralphy`, `qte77/research-ralphy`) need to be created on GitHub
- Ralph added as git submodule in each
- `ANTHROPIC_API_KEY` secret set for GHA weekly cron

## Test plan
- [ ] Create GitHub repos with broader-scoped PAT
- [ ] `git submodule add` ralph in each
- [ ] Push scaffolded files (already at `/workspaces/qte77/{learnings,research}-ralphy/`)
- [ ] `make ralph_status` succeeds in each repo
- [ ] `workflow_dispatch` triggers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)