### PR TITLE
feat: multi-project contribution infrastructure (rebased from #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Agent Instructions
+
+**Behavioral rules, compliance requirements, and decision frameworks for AI coding
+agents.** For technical workflows and coding standards, see
+[CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
+[README.md](README.md).
+
+**External References:**
+
+- @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
+- @AGENT_REQUESTS.md - Escalation and human collaboration
+- @AGENT_LEARNINGS.md - Pattern discovery and knowledge sharing
+
+## Claude Code Infrastructure
+
+**Rules** (`.claude/rules/`): Session-loaded constraints (always active)
+**Skills** (`.claude/skills/`): Modular capabilities with progressive disclosure
+
+## Core Rules & AI Behavior
+
+- Follow SDLC principles: maintainability, modularity, reusability, adaptability
+- **Never assume missing context** - Ask questions if uncertain about requirements
+- **Never hallucinate libraries** - Only use packages verified in project dependencies
+- **Always confirm file paths exist** before referencing in code or tests
+- **Never delete existing code** unless explicitly instructed or documented refactoring
+- **Document new patterns** in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- **Request human feedback** in AGENT_REQUESTS.md (concise, laser-focused, streamlined)
+
+## Decision Framework
+
+**Priority Order:** User instructions > AGENTS.md compliance > Documentation
+hierarchy > Project patterns > General best practices
+
+**Anti-Scope-Creep Rules:**
+
+- **NEVER implement features without requirement validation**
+- **Always validate implementation decisions against project scope boundaries**
+
+**Anti-Redundancy Rules:**
+
+- **NEVER duplicate information across documents** - reference authoritative sources
+- **Update authoritative document, then remove duplicates elsewhere**
+
+**When to Escalate to AGENT_REQUESTS.md:**
+
+- User instructions conflict with safety/security practices
+- AGENTS.md rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+
+## Agent Neutrality Requirements
+
+**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+
+1. **Extract requirements from specified documents ONLY**
+   - Read provided task descriptions or reference materials
+   - Do NOT make assumptions about unstated requirements
+   - Do NOT add functionality not explicitly requested
+
+2. **Request clarification for ambiguous scope**
+   - If task boundaries are unclear, ASK for clarification
+   - If complexity level is not specified, ASK for target complexity
+   - Do NOT assume scope or make architectural decisions without validation
+
+3. **Design to stated requirements exactly**
+   - Match the complexity level requested
+   - Follow "minimal," "streamlined," or "focused" guidance literally
+   - Do NOT over-engineer solutions beyond stated needs
+
+## Compliance Requirements
+
+1. **Command Execution**: Use project make recipes or standard tooling
+2. **Quality Validation**: Run validation before task completion; fix ALL issues
+3. **Coding Style**: Follow existing project patterns and conventions
+4. **Documentation Updates**: Update docs when introducing new patterns
+5. **Testing**: Create tests for new functionality
+6. **Code Standards**: Use absolute imports, add `# Reason:` comments for complex logic
+
+## Quality Thresholds
+
+**Before starting any task, ensure:**
+
+- **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
+- **Clarity**: 7/10 - Clear implementation path and expected outcomes
+- **Alignment**: 8/10 - Follows project patterns and architectural decisions
+- **Success**: 7/10 - Confident in completing task correctly
+
+### Below Threshold Action
+
+Gather more context or escalate to AGENT_REQUESTS.md
+
+## Agent Quick Reference
+
+**Pre-Task:**
+
+- Read AGENTS.md > CONTRIBUTING.md for technical details
+- Verify quality thresholds met
+
+**During Task:**
+
+- Use project commands (document deviations)
+- Follow existing patterns and conventions
+- Update documentation when learning patterns
+
+**Post-Task:**
+
+- Run validation - must pass all checks (code tasks only)
+- Update CHANGELOG.md for non-trivial changes
+- Document new patterns in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- Escalate to AGENT_REQUESTS.md if blocked

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -1,0 +1,14 @@
+---
+title: Agent Learning Documentation
+description: Non-obvious patterns that prevent repeated mistakes across sprints
+---
+
+## Template
+
+- **Context**: When/where this applies
+- **Problem**: What issue this solves
+- **Solution**: Implementation approach
+- **Example**: Working code
+- **References**: Related files
+
+## Learned Patterns

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -1,0 +1,18 @@
+---
+title: Agent Requests to Humans
+description: Escalation protocol and active requests requiring human decision
+---
+
+**Always escalate when:**
+
+- User instructions conflict with safety/security practices
+- Rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+- Critical dependencies unavailable
+
+**Format:** `- [ ] [PRIORITY] Description` with Context, Problem, Files, Alternatives, Impact
+
+## Active Requests
+
+None.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ SHELL := /bin/bash
 .PHONY: \
 	help setup_all setup_repos setup_vscode setup_gh_auth setup_claude_code \
 	setup_claude_sandbox setup_rtk setup_npm_tools setup_lychee \
-	generate_tasks clone_repos
+	generate_tasks clone_repos \
+	contrib_setup contrib_triage contrib_implement contrib_review \
+	contrib_status contrib_cleanup
 .DEFAULT_GOAL := help
 
 # Source colors for all recipes
@@ -139,6 +141,52 @@ generate_tasks:  ## Generate workspace.code-workspace from config/repos.conf
 	$(_src_colors)
 	info "Generating vscode tasks..."
 	bash scripts/generate-tasks.sh
+
+
+# MARK: CONTRIB
+
+
+contrib_setup:  ## Fork + clone external contribution repos
+	$(_src_colors)
+	info "Setting up contribution repos (fork + clone + upstream)..."
+	bash scripts/clone-repos.sh
+	success "Contribution repos ready"
+
+contrib_triage:  ## Triage issues across contribution repos
+	$(_src_colors)
+	info "Launching triage agents..."
+	bash scripts/cc-parallel.sh --preset contribute --mode triage
+
+contrib_implement:  ## Run TDD implementation agents on contribution repos
+	$(_src_colors)
+	info "Launching implementation agents..."
+	bash scripts/cc-parallel.sh --preset contribute --mode implement
+
+contrib_review:  ## Run review agents on contribution repos
+	$(_src_colors)
+	info "Launching review agents..."
+	bash scripts/cc-parallel.sh --preset contribute --mode review
+
+contrib_status:  ## Show contribution dashboard (forks, branches, PRs)
+	$(_src_colors)
+	bash scripts/contrib-status.sh
+
+contrib_cleanup:  ## Prune worktrees and stale contribution branches
+	$(_src_colors)
+	source scripts/load-workspace-repos.sh
+	for i in $${!GH_REPOS[@]}; do \
+		[[ "$${FORK_FLAGS[$$i]:-}" != "fork" ]] && continue; \
+		path="$${REPOS[$$((i+1))]}"; \
+		[[ -d "$$path/.git" ]] || continue; \
+		name="$${REPO_NAMES[$$((i+1))]}"; \
+		info "$$name: pruning worktrees..."; \
+		git -C "$$path" worktree prune 2>/dev/null || true; \
+		wt_dir="$${path}-worktrees"; \
+		if [[ -d "$$wt_dir" ]] && [[ -z "$$(ls -A "$$wt_dir" 2>/dev/null)" ]]; then \
+			rmdir "$$wt_dir" 2>/dev/null || true; \
+		fi; \
+	done
+	success "Cleanup complete"
 
 
 # MARK: HELP

--- a/config/prompts/bulk-file-loader.env
+++ b/config/prompts/bulk-file-loader.env
@@ -1,0 +1,4 @@
+TECH_STACK="Go"
+SKILLS="/go-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="patent-dev/bulk-file-loader"
+DEFAULT_ISSUES=""

--- a/config/prompts/compass-mcp.env
+++ b/config/prompts/compass-mcp.env
@@ -1,0 +1,4 @@
+TECH_STACK="TypeScript"
+SKILLS="/typescript-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="richlira/compass-mcp"
+DEFAULT_ISSUES=""

--- a/config/prompts/contribute-implement.md
+++ b/config/prompts/contribute-implement.md
@@ -1,0 +1,40 @@
+You are implementing a fix/feature for issue(s) {{ISSUES}} in a fork of {{UPSTREAM}} ({{TECH_STACK}} stack).
+
+## Setup
+
+1. Ensure you are on a clean branch: `git checkout -b contrib/{{ISSUES}}-work`
+2. Use /codebase-tools:researching-codebase to understand the codebase before making changes
+
+## Implementation (Strict TDD — tests first)
+
+3. Use /tdd-core:testing-tdd with strict Red-Green-Refactor:
+   a. RED: Write failing tests that define the expected behavior FIRST
+   b. GREEN: Write the minimal implementation to make tests pass
+   c. REFACTOR: Clean up while keeping tests green
+4. Use {{SKILLS}} for language-specific best practices
+5. Run the full test suite after each cycle to ensure no regressions
+6. NEVER write implementation code before its corresponding test exists
+
+## Context Management
+
+7. Use /cc-meta:compacting-context at these milestones:
+   - After initial exploration (before coding)
+   - After implementation (before testing)
+   - After testing (before PR creation)
+
+## Commit and PR
+
+8. Stage and commit with /commit-helper:committing-staged-with-message (conventional commits)
+9. Push the branch: `git push -u origin contrib/{{ISSUES}}-work`
+10. Create PR to upstream:
+    ```
+    gh pr create --repo {{UPSTREAM}} \
+      --title "<concise title>" \
+      --body "Fixes #{{ISSUES}}\n\n## Summary\n<description>\n\n## Test plan\n<how to verify>"
+    ```
+
+## Constraints
+
+- Follow CONTRIBUTING.md if present
+- Do not introduce new dependencies without justification
+- Keep changes minimal and focused on the issue

--- a/config/prompts/contribute-review.md
+++ b/config/prompts/contribute-review.md
@@ -1,0 +1,25 @@
+You are reviewing an open PR in {{UPSTREAM}} ({{TECH_STACK}} stack).
+
+## Objective
+
+Provide a thorough, constructive code review.
+
+## Steps
+
+1. List open PRs: `gh pr list -R {{UPSTREAM}} --json number,title,author`
+2. Check out the PR locally: `gh pr checkout <number> -R {{UPSTREAM}}`
+3. Use /codebase-tools:researching-codebase to understand the context of the changes
+4. Review the diff: `git diff main...HEAD`
+5. Run tests if a test suite exists
+6. Assess:
+   - Correctness: Does it fix the stated issue?
+   - Style: Does it follow project conventions?
+   - Tests: Are changes adequately tested?
+   - Security: Any OWASP concerns?
+7. Post review via `gh pr review <number> -R {{UPSTREAM}} --comment --body "<review>"`
+
+## Constraints
+
+- Be constructive and specific — reference file:line
+- Do NOT approve or request changes — comment only (we are external contributors)
+- Use /cc-meta:compacting-context if context exceeds 50%

--- a/config/prompts/contribute-triage.md
+++ b/config/prompts/contribute-triage.md
@@ -1,0 +1,24 @@
+You are triaging issue(s) {{ISSUES}} in the {{UPSTREAM}} repository ({{TECH_STACK}} stack).
+
+## Objective
+
+Explore the codebase, understand the issue(s), assess complexity, and post a triage comment.
+
+## Steps
+
+1. Use /codebase-tools:researching-codebase to explore the repo structure, dependencies, and conventions
+2. Read the issue description and any existing comments via `gh issue view {{ISSUES}} -R {{UPSTREAM}}`
+3. Identify the relevant source files and understand the root cause or feature scope
+4. Assess complexity (low/medium/high) and estimate effort
+5. Draft a triage comment with:
+   - Root cause analysis or feature scope breakdown
+   - Proposed implementation approach
+   - Files that need changes
+   - Test strategy
+6. Post the comment: `gh issue comment <number> -R {{UPSTREAM}} --body "<comment>"`
+
+## Constraints
+
+- Do NOT make code changes — this is read-only triage
+- Do NOT create branches or commits
+- Use /cc-meta:compacting-context if context exceeds 50%

--- a/config/prompts/dpma-connect-plus.env
+++ b/config/prompts/dpma-connect-plus.env
@@ -1,0 +1,4 @@
+TECH_STACK="Go"
+SKILLS="/go-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="patent-dev/dpma-connect-plus"
+DEFAULT_ISSUES=""

--- a/config/prompts/epo-bdds.env
+++ b/config/prompts/epo-bdds.env
@@ -1,0 +1,4 @@
+TECH_STACK="Go"
+SKILLS="/go-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="patent-dev/epo-bdds"
+DEFAULT_ISSUES=""

--- a/config/prompts/epo-ops.env
+++ b/config/prompts/epo-ops.env
@@ -1,0 +1,4 @@
+TECH_STACK="Go"
+SKILLS="/go-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="patent-dev/epo-ops"
+DEFAULT_ISSUES="1,2"

--- a/config/prompts/openclaude.env
+++ b/config/prompts/openclaude.env
@@ -1,0 +1,4 @@
+TECH_STACK="TypeScript"
+SKILLS="/typescript-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="Gitlawb/openclaude"
+DEFAULT_ISSUES="343"

--- a/config/prompts/openclaudia-skills.env
+++ b/config/prompts/openclaudia-skills.env
@@ -1,0 +1,4 @@
+TECH_STACK="JS/Markdown"
+SKILLS="/gha-dev:creating-gha /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="OpenClaudia/openclaudia-skills"
+DEFAULT_ISSUES="7,2"

--- a/config/prompts/simpleagents.env
+++ b/config/prompts/simpleagents.env
@@ -1,0 +1,4 @@
+TECH_STACK="Rust"
+SKILLS="/rust-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="CraftsMan-Labs/SimpleAgents"
+DEFAULT_ISSUES="23,47"

--- a/config/prompts/uspto-odp.env
+++ b/config/prompts/uspto-odp.env
@@ -1,0 +1,4 @@
+TECH_STACK="Go"
+SKILLS="/go-dev /tdd-core:testing-tdd /codebase-tools:researching-codebase /cc-meta:compacting-context /commit-helper:committing-staged-with-message"
+UPSTREAM="patent-dev/uspto-odp"
+DEFAULT_ISSUES=""

--- a/scripts/contrib-status.sh
+++ b/scripts/contrib-status.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# contrib-status.sh — Contribution dashboard across all fork repos
+# Shows fork status, branches, open PRs, and worktrees
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/load-workspace-repos.sh"
+source "${SCRIPT_DIR}/colors.sh"
+
+# Header
+printf "%-22s %-20s %-7s %-12s %s\n" "REPO" "BRANCH" "STATUS" "UPSTREAM" "OPEN PRS"
+printf "%-22s %-20s %-7s %-12s %s\n" "----" "------" "------" "--------" "--------"
+
+for i in "${!GH_REPOS[@]}"; do
+  [[ "${FORK_FLAGS[$i]:-}" != "fork" ]] && continue
+
+  gh_repo="${GH_REPOS[$i]}"
+  path="${REPOS[$((i+1))]}"
+  name="${REPO_NAMES[$((i+1))]}"
+
+  if [[ ! -d "$path/.git" ]]; then
+    printf "%-22s %s\n" "$name" "$(warn '(not cloned)')"
+    continue
+  fi
+
+  # Branch
+  branch=$(git -C "$path" branch --show-current 2>/dev/null || echo "detached")
+
+  # Clean/dirty
+  if git -C "$path" diff --quiet HEAD 2>/dev/null && \
+     [[ -z "$(git -C "$path" status --porcelain 2>/dev/null)" ]]; then
+    status="clean"
+  else
+    changed=$(git -C "$path" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    status="${changed}m"
+  fi
+
+  # Upstream sync status
+  upstream_status="unknown"
+  if git -C "$path" remote get-url upstream &>/dev/null; then
+    local_head=$(git -C "$path" rev-parse HEAD 2>/dev/null)
+    upstream_head=$(git -C "$path" rev-parse upstream/main 2>/dev/null || \
+                    git -C "$path" rev-parse upstream/master 2>/dev/null || echo "")
+    if [[ -n "$upstream_head" ]]; then
+      if [[ "$local_head" == "$upstream_head" ]]; then
+        upstream_status="synced"
+      else
+        behind=$(git -C "$path" rev-list --count HEAD..upstream/main 2>/dev/null || \
+                 git -C "$path" rev-list --count HEAD..upstream/master 2>/dev/null || echo "?")
+        upstream_status="${behind} behind"
+      fi
+    fi
+  fi
+
+  # Count open PRs by us on upstream
+  pr_count=$(gh pr list -R "$gh_repo" --author "@me" --state open --json number 2>/dev/null | \
+             jq 'length' 2>/dev/null || echo "?")
+
+  printf "%-22s %-20s %-7s %-12s %s\n" "$name" "$branch" "$status" "$upstream_status" "$pr_count"
+
+  # Show worktrees
+  worktree_dir="${path}-worktrees"
+  if [[ -d "$worktree_dir" ]]; then
+    for wt in "$worktree_dir"/contrib-*; do
+      [[ -d "$wt" ]] || continue
+      wt_branch=$(git -C "$wt" branch --show-current 2>/dev/null || echo "?")
+      printf "  %-20s %s\n" "$(basename "$wt")" "$wt_branch"
+    done
+  fi
+done
+
+echo ""


### PR DESCRIPTION
## Summary
Surgical rebase of PR #34 — additive files only, zero SOT conflicts.

- Contribution workflow prompts: triage / implement / review
- 9 per-project env files (4 OSS + 5 patent-dev Go targets)
- `scripts/contrib-status.sh` dashboard
- `AGENTS.md`, `AGENT_LEARNINGS.md`, `AGENT_REQUESTS.md` governance
- Makefile CONTRIB section: `contrib_setup/triage/implement/review/status/cleanup`

## Why
PR #34 had 54 commits of pre-`repos.conf`-SOT history that conflicted architecturally with PR #33. This PR keeps only the contribution workflow layer that's purely additive on top of current main.

## Deferred to follow-up
- `cc-parallel.sh --preset contribute` wiring (needs re-implementation against new cc-parallel.sh)
- `package.json`/`package-lock.json` additions (YAGNI review pending)

## Test plan
- [ ] `make help` shows new CONTRIB section
- [ ] `make contrib_status` runs
- [ ] `make contrib_setup` (requires PAT with fork scope)
- [ ] PR #34 can be closed after this merges

Closes PR #34 superseded.

Generated with Claude <noreply@anthropic.com>