### PR TITLE
fix: sync repos.conf (rename cc-utils, add ralphy repos)

### DIFF
--- a/config/repos.conf
+++ b/config/repos.conf
@@ -6,6 +6,8 @@ qte77/Agents-eval:Agents-eval
 qte77/ai-agents-research:cc-research
 qte77/RAPID-spec-forge:RAPID-spec-forge
 qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template:ralph-template
-qte77/claude-code-utils-plugin:cc-utils-plugin
+qte77/claude-code-plugins:cc-plugins
 qte77/deepvariant-linux-arm64:deepvariant
 qte77/dotfiles:dotfiles
+qte77/learnings-ralphy:learnings-ralphy
+qte77/research-ralphy:research-ralphy


### PR DESCRIPTION
## Summary
- Rename `claude-code-utils-plugin` → `claude-code-plugins` (repo was renamed upstream Apr 13; fixes broken clone)
- Add `learnings-ralphy` and `research-ralphy` (supersedes PR #35)

## Closes
- #35 (superseded — same intent, rebased on current SOT)

Generated with Claude <noreply@anthropic.com>