### PR TITLE
chore: enable 7 CC plugins from qte77 marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
+  },
+  "enabledPlugins": {
+    "planning@qte77-claude-code-plugins": true,
+    "commit-helper@qte77-claude-code-plugins": true,
+    "docs-governance@qte77-claude-code-plugins": true,
+    "cc-meta@qte77-claude-code-plugins": true,
+    "makefile-core@qte77-claude-code-plugins": true,
+    "workspace-setup@qte77-claude-code-plugins": true,
+    "readme-generator@qte77-claude-code-plugins": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-plugins"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ workspace.code-workspace
 node_modules/
 
 # CC runtime artifacts (deployed by plugin + dotfiles)
-.claude/
+.claude/*
+!.claude/settings.json
 settings.local.json
 
 # CC Sandbox device nodes (denyWithinAllow artifacts)


### PR DESCRIPTION
Enables planning, commit-helper, docs-governance, cc-meta, makefile-core, workspace-setup, and readme-generator. Carves .claude/settings.json out of the gitignore for runtime artifacts so the plugin list is tracked as project config.

Generated with Claude <noreply@anthropic.com>