### PR TITLE
chore(makefile): durable GPG signing config in setup_gh_auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,12 @@ setup_all:  ## Run all setup steps (non-fatal: failures warn, don't abort)
 	done
 	success "Setup complete"
 
-setup_gh_auth:  ## Configure gh as git credential helper (uses GH_TOKEN from containerEnv)
+setup_gh_auth:  ## Configure gh as git credential helper + durable GPG signing config
 	$(_src_colors)
 	if command -v gh > /dev/null 2>&1; then gh auth setup-git; \
 	else warn "gh cli not installed. skipping auth."; fi
+	git config --global commit.gpgsign true
+	git config --global gpg.format openpgp
 
 setup_claude_code:  ## Setup claude code CLI
 	$(_src_colors)


### PR DESCRIPTION
## Summary
Closes #48.

Codespaces' *Trusted repositories: All* toggle writes `commit.gpgsign=true` at container creation **if set before creation**. Sibling-cloned repos and toggle-after-creation cases don't inherit it. This PR makes signing durable by writing the two lines from `setup_gh_auth`:

```makefile
git config --global commit.gpgsign true
git config --global gpg.format openpgp
```

Idempotent — safe to run when the values are already set.

## Authority chain
This is **mechanism**. The corresponding **policy** doc lives in qte77/qte77 (PR qte77/qte77#62 — `docs/gpg-signing.md`). Mechanism here, policy there, per the team-OS authority split.

## Test plan
- [ ] `make setup_gh_auth` succeeds without error
- [ ] After running it, `git config --global commit.gpgsign` returns `true`
- [ ] After running it, `git config --global gpg.format` returns `openpgp`
- [ ] Open a fresh Codespace as final smoke test (signed commits work in sibling-cloned repo without manual setup)

Generated with Claude <noreply@anthropic.com>