### PR TITLE
chore: housekeeping (gitignore, repos.conf, jscpd bump)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 workspace.code-workspace
 node_modules/
+MEMORY.md
 
 # CC runtime artifacts (deployed by plugin + dotfiles)
 .claude/*

--- a/config/repos.conf
+++ b/config/repos.conf
@@ -2,12 +2,7 @@
 # Format: owner/repo:display-name
 # Cloned to ../owner/repo relative to polyforge root
 # polyforge itself is always included implicitly
-qte77/Agents-eval:Agents-eval
-qte77/ai-agents-research:cc-research
-qte77/RAPID-spec-forge:RAPID-spec-forge
-qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template:ralph-template
 qte77/claude-code-plugins:cc-plugins
-qte77/deepvariant-linux-arm64:deepvariant
-qte77/dotfiles:dotfiles
-qte77/learnings-ralphy:learnings-ralphy
-qte77/research-ralphy:research-ralphy
+qte77/doc-pipeline-engine:doc-pipeline-engine
+qte77/office-forge-orchestrator:office-forge
+qte77/polyfetch-scrape:polyfetch-scrape

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "polyforge",
+  "name": "polyforge-orchestrator",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
-        "jscpd": "^4.0.8",
+        "jscpd": "^4.0.9",
         "markdownlint-cli": "^0.48.0"
       }
     },
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@jscpd/badge-reporter": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.0.4.tgz",
-      "integrity": "sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.0.5.tgz",
+      "integrity": "sha512-SLVhP00R9lkQ//Ivaanfm7k0L9sewpBven670kk1uGec2SWUOa7MVQcuad/TV59KEZ73UIC1lXvi6O9hAnbpUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@jscpd/core": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.0.4.tgz",
-      "integrity": "sha512-QGMT3iXEX1fI6lgjPH+x8eyJwhwr2KkpSF5uBpjC0Z5Xloj0yFTFLtwJT+RhxP/Ob4WYrtx2jvpKB269oIwgMQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.0.5.tgz",
+      "integrity": "sha512-Udvym21nWzxjYRVXwwpYNBqZ6b50QV2zHN3fFNzOPPg4cfQVYOZerILB7xNDUsXHC1PCr/N52Tq3q7AElvjWWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -93,14 +93,14 @@
       }
     },
     "node_modules/@jscpd/finder": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.0.4.tgz",
-      "integrity": "sha512-qVUWY7Nzuvfd5OIk+n7/5CM98LmFroLqblRXAI2gDABwZrc7qS+WH2SNr0qoUq0f4OqwM+piiwKvwL/VDNn/Cg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.0.5.tgz",
+      "integrity": "sha512-/2VkRoVrrfya+51sitZo5I9MdwsRaPKB8X3L3khAYoHFXk4L/mUuG81RmGazDHjUIGg22ItlkQtwzorNZ2+aPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/core": "4.0.4",
-        "@jscpd/tokenizer": "4.0.4",
+        "@jscpd/core": "4.0.5",
+        "@jscpd/tokenizer": "4.0.5",
         "blamer": "^1.0.6",
         "bytes": "^3.1.2",
         "cli-table3": "^0.6.5",
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@jscpd/html-reporter": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.0.4.tgz",
-      "integrity": "sha512-YiepyeYkeH74Kx59PJRdUdonznct0wHPFkf6FLQN+mCBoy6leAWCcOfHtcexnp+UsBFDlItG5nRdKrDSxSH+Kg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.0.5.tgz",
+      "integrity": "sha512-drK2J8KyPIW9wvaElSIobZFp4dBO9GA++JW4gx3oihvLdDSp8qSo/CNqH47Dw0XkjQTxND3j/+Wz5JWvYRBgFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -124,13 +124,13 @@
       }
     },
     "node_modules/@jscpd/tokenizer": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.0.4.tgz",
-      "integrity": "sha512-xxYYY/qaLah/FlwogEbGIxx9CjDO+G9E6qawcy26WwrflzJb6wsnhjwdneN6Wb0RNCDsqvzY+bzG453jsin4UQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.0.5.tgz",
+      "integrity": "sha512-WzRujQtN5WedxZVDKuoanxmKAFrxcLrHpcA6kaM4z8AhGtWXZ325yseqgL5TZ8OK7Auwu7kQLlqhfk05fGYG7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/core": "4.0.4",
+        "@jscpd/core": "4.0.5",
         "reprism": "^0.0.11",
         "spark-md5": "^3.0.2"
       }
@@ -786,16 +786,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gitignore-to-glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/gitignore-to-glob/-/gitignore-to-glob-0.3.0.tgz",
-      "integrity": "sha512-mk74BdnK7lIwDHnotHddx1wsjMOFIThpLY3cPNniJ/2fA/tlLzHnFxIdR+4sLOu5KGgQJdij4kjJ2RoUNnCNMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.4 <5 || >=6.9"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -859,9 +849,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1086,31 +1076,30 @@
       }
     },
     "node_modules/jscpd": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.0.8.tgz",
-      "integrity": "sha512-d2VNT/2Hv4dxT2/59He8Lyda4DYOxPRyRG9zBaOpTZAqJCVf2xLrBlZkT8Va6Lo9u3X2qz8Bpq4HrDi4JsrQhA==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.0.9.tgz",
+      "integrity": "sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/badge-reporter": "4.0.4",
-        "@jscpd/core": "4.0.4",
-        "@jscpd/finder": "4.0.4",
-        "@jscpd/html-reporter": "4.0.4",
-        "@jscpd/tokenizer": "4.0.4",
+        "@jscpd/badge-reporter": "4.0.5",
+        "@jscpd/core": "4.0.5",
+        "@jscpd/finder": "4.0.5",
+        "@jscpd/html-reporter": "4.0.5",
+        "@jscpd/tokenizer": "4.0.5",
         "colors": "^1.4.0",
         "commander": "^5.0.0",
         "fs-extra": "^11.2.0",
-        "gitignore-to-glob": "^0.3.0",
-        "jscpd-sarif-reporter": "4.0.6"
+        "jscpd-sarif-reporter": "4.0.7"
       },
       "bin": {
         "jscpd": "bin/jscpd"
       }
     },
     "node_modules/jscpd-sarif-reporter": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.0.6.tgz",
-      "integrity": "sha512-b9Sm3IPZ3+m8Lwa4gZa+4/LhDhlc/ZLEsLXKSOy1DANQ6kx0ueqZT+fUHWEdQ6m0o3+RIVIa7DmvLSojQD05ng==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.0.7.tgz",
+      "integrity": "sha512-Q/VlfTI/Nbjc8dZ/2pDVIf1aRi2bM2CTYujcAoeYr7brRnS4o5ZeW86W8q7MM7cQu40gezlNckl+E9wKFSMFiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1127,9 +1116,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2282,12 +2271,13 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "jscpd": "^4.0.8",
+    "jscpd": "^4.0.9",
     "markdownlint-cli": "^0.48.0"
   }
 }


### PR DESCRIPTION
## Summary
- Ignore `MEMORY.md` auto-memory artifact
- Sync `repos.conf` with current GitHub state (drop 8 stale entries, add 3 new repos)
- Bump `jscpd` to `^4.0.9`

## Test plan
- [ ] CI passes
- [ ] `make setup_all` still resolves repos correctly