### PR TITLE
fix: auto-allow workspace tasks for tiled terminal startup

### DIFF
--- a/scripts/generate-tasks.sh
+++ b/scripts/generate-tasks.sh
@@ -37,11 +37,16 @@ for i in "${!REPOS[@]}"; do
     }]')
 done
 
-# Write workspace file (folders + tasks)
+# Write workspace file (folders + settings + tasks)
+# task.allowAutomaticTasks: "on" lets folderOpen tasks run without the per-workspace prompt
 jq -n \
   --argjson folders "$folders" \
   --argjson tasks "$tasks" \
-  '{folders: $folders, tasks: {version: "2.0.0", tasks: $tasks}}' \
+  '{
+    folders: $folders,
+    settings: {"task.allowAutomaticTasks": "on"},
+    tasks: {version: "2.0.0", tasks: $tasks}
+  }' \
   > "$WORKSPACE_FILE"
 
 success "Generated $WORKSPACE_FILE with ${#REPOS[@]} repos and tasks"


### PR DESCRIPTION
## Summary
- Embed `task.allowAutomaticTasks: "on"` in the generated `workspace.code-workspace`
- Lets `runOn: folderOpen` tasks fire on workspace open without the per-workspace permission prompt

## Why
Reopening the workspace was supposed to spawn one tiled terminal per repo. VS Code silently blocks this until you accept "Allow Automatic Tasks" via Command Palette. Baking the setting in removes the friction.

## Test plan
- [x] `bash scripts/generate-tasks.sh` produces valid JSON with `settings` block
- [x] Reopen `workspace.code-workspace` → terminals tile automatically (verified locally: panes for polyforge, office-forge-orchestrator, doc-pipeline-engine, polyfetch-scrape all spawn with correct `pwd`)