### PR TITLE
fix(devcontainer): regenerate workspace tasks on attach

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,5 +40,5 @@
     "RTK_TELEMETRY_DISABLED": "1"
   },
   "onCreateCommand": "make setup_all",
-  "postAttachCommand": "make setup_repos"
+  "postAttachCommand": "make setup_repos generate_tasks"
 }


### PR DESCRIPTION
## Summary
- `postAttachCommand` now runs `make setup_repos generate_tasks`
- Keeps `workspace.code-workspace` in sync with `config/repos.conf` on every container attach

## Why
`generate_tasks` only ran via `onCreateCommand` (one-shot at container creation). After editing `repos.conf`, the workspace file went stale until manual rebuild.

## Test plan
- [x] Detach + reattach container → workspace.code-workspace reflects current repos.conf