### PR TITLE
fix(plugins): correct marketplace name to qte77-claude-code-utils

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,16 +4,16 @@
     "pr": "Generated with Claude <noreply@anthropic.com>"
   },
   "enabledPlugins": {
-    "planning@qte77-claude-code-plugins": true,
-    "commit-helper@qte77-claude-code-plugins": true,
-    "docs-governance@qte77-claude-code-plugins": true,
-    "cc-meta@qte77-claude-code-plugins": true,
-    "makefile-core@qte77-claude-code-plugins": true,
-    "workspace-setup@qte77-claude-code-plugins": true,
-    "readme-generator@qte77-claude-code-plugins": true
+    "planning@qte77-claude-code-utils": true,
+    "commit-helper@qte77-claude-code-utils": true,
+    "docs-governance@qte77-claude-code-utils": true,
+    "cc-meta@qte77-claude-code-utils": true,
+    "makefile-core@qte77-claude-code-utils": true,
+    "workspace-setup@qte77-claude-code-utils": true,
+    "readme-generator@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-plugins": {
+    "qte77-claude-code-utils": {
       "source": {
         "source": "github",
         "repo": "qte77/claude-code-plugins"


### PR DESCRIPTION
## Summary
- Rename marketplace key from `qte77-claude-code-plugins` (repo name) to `qte77-claude-code-utils` (declared marketplace name) in `.claude/settings.json`
- Affects 7 enabled plugins + 1 `extraKnownMarketplaces` entry

## Why
The repo `qte77/claude-code-plugins` self-identifies its marketplace as `qte77-claude-code-utils` (per `.claude-plugin/marketplace.json`). Our settings used the repo name, so `/reload-plugins` reported all 7 plugins as missing.

## Test plan
- [ ] `/reload-plugins` reports 0 errors
- [ ] `/doctor` shows no marketplace mismatches