### PR TITLE
docs(readme): rewrite hero intro + tighten devcontainer-bridge explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 <!-- markdownlint-disable MD033 -->
 # polyforge-orchestrator
 
-Orchestrate parallel AI coding agents across
-a polyrepo codebase from a single Codespace
-or devcontainer.
+Orchestrate parallel AI coding agents across a polyrepo codebase from a single devcontainer or vscode workspace.
 
-**For** teams running Claude Code (or other AI agents)
-across multiple repos simultaneously.
-**Run** `./scripts/cc-parallel.sh --preset validate`
-to validate all repos in one command.
+Run Claude Code (or any AI coding agent) in parallel across every repo in a polyrepo workspace from a single devcontainer. Generates a multi-root VS Code workspace with per-repo terminal tasks, bridges each repo's `devcontainer.json` lifecycle into the host container, and ships validate/security/test presets plus a contribution-task registry. Driven by `config/repos.conf` + `config/contributions.json`.
+
+**For** teams running Claude Code (or other AI agents) across multiple repos simultaneously.
+**Run** `./scripts/cc-parallel.sh --preset validate` to validate all repos in one command.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ shared tooling (Claude Code, RTK, lychee, markdownlint),
 clones all repos from `config/repos.conf`, and generates
 `workspace.code-workspace` with terminal tasks per repo.
 
-On attach (`make setup_repos`), it reads each repo's
-`devcontainer.json` and runs their `onCreateCommand` +
-`postCreateCommand` inside the host container — bridging
-the gap where multi-root workspaces only run the host
-container's devcontainer lifecycle.
+On attach (`make setup_repos`), polyforge reads each
+sibling repo's `devcontainer.json` and replays their
+`onCreateCommand` / `postCreateCommand` inside the host
+container. VS Code multi-root workspaces only honor the
+host container's lifecycle, so sibling hooks would
+otherwise be silently dropped — per-repo setup (deps,
+tooling, hooks) would never run.
 
 Terminal tasks auto-open via `runOn: folderOpen` in both
 VS Code Desktop and Web.


### PR DESCRIPTION
## Summary

Two commits, two topics, both in `README.md`:

### 1. Hero intro rewrite (`56e5141`)
- Broaden framing from "Codespace or devcontainer" → "devcontainer or vscode workspace".
- Replace single-paragraph tagline with **two-paragraph hero**: short headline + dense feature-list sentence covering multi-root workspace generation, devcontainer lifecycle bridging, validate/security/test presets, and the contribution-task registry.
- Collapse the For/Run hook from four lines to two.

### 2. Devcontainer-bridge explanation refresh (`999865f`)
- Restructure the How It Works lifecycle paragraph: lead with the mechanism (read + replay sibling devcontainer hooks post-attach), then name what would otherwise break (silently dropped hooks; per-repo setup would never run).
- Was a single sentence using "bridging the gap"; now two sentences with explicit problem statement so readers understand *why* this scaffolding exists.

No code or config changes; docs only.

## Test plan

- [ ] CI passes (CodeFactor; no markdownlint workflow currently)
- [ ] README.md renders correctly on GitHub (preview)
- [ ] No broken links introduced (existing docs/ links unchanged)
- [ ] H1 unchanged (`# polyforge-orchestrator`)
- [ ] Quick Start, How It Works (modulo lifecycle paragraph), Docs sections structurally intact
- [ ] `markdownlint-disable MD033` directive preserved at top

Generated with Claude <noreply@anthropic.com>