### PR TITLE
docs: link the qte77 Startup CTO Handbook mapping (engineering-practice baseline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `README.md`: "Engineering-practice baseline" Docs link → the qte77 estate note mapping the dev-loop presets (DevOps / testing / RCA) onto the Startup CTO Handbook
 - `docs/codespaces.md`: token format prefix table (`ghu_` / `github_pat_` / etc., 1p-cited); GPG-signing diagnostics audit one-liner; reset/rebuild scope table; inherited-git-config subsection covering `commit.template` per-repo override; expanded References block with 1p `docs.github.com/en/codespaces/...` URLs. Absorbs research that was previously kept in `qte77/polyfetch-scrape/docs/codespaces-*.md` (now removed there in favour of this canonical home).
 - `docs/codespaces.md` "Caveat: `GH_TOKEN=$GH_PAT` mapping may break `gh-gpgsign`" subsection — unverified hypothesis with side-by-side reproduction, confirming probe, and small fix path. Tracked under #64.
 - `scripts/generate-workspace.sh`: generates `workspace.code-workspace` (folders only) from `repos.conf` for multi-root sidebar

--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ VS Code Desktop and Web.
 - [Cross-repo setup](docs/cross-repo-setup.md) — auth, sandbox, settings
 - [Cloud workflows](docs/cc-web-cloud-workflows.md) — remote execution
 - [Sandbox friction](docs/sandbox-friction.md) — known issues, mitigations
+- [Engineering-practice baseline](https://github.com/qte77/qte77/blob/main/docs/cto-handbook-mapping.md) — how the dev-loop presets (DevOps / testing / RCA) map to the Startup CTO Handbook (estate-level note in qte77)


### PR DESCRIPTION
## What

Adds a README `## Docs` pointer to the estate-level note in qte77
([qte77/qte77#133](https://github.com/qte77/qte77/pull/133), merged) that maps the
dev-loop presets (DevOps / testing / RCA) onto the *Startup CTO Handbook*. Plus a
`CHANGELOG` entry.

A **light cross-repo pointer** — the substantive mapping lives once in qte77 (DRY).

Generated with Claude <noreply@anthropic.com>
